### PR TITLE
feat(issue-21): show ancestors and descendants simultaneously in family tree

### DIFF
--- a/src/app/api/tree/[rootId]/route.test.ts
+++ b/src/app/api/tree/[rootId]/route.test.ts
@@ -114,7 +114,7 @@ describe('GET /api/tree/[rootId]', () => {
       id: 'rel:1',
       source: 'node:1',
       target: 'node:2',
-      label: 'CHILD',
+      relType: 'CHILD',
     })
   })
 

--- a/src/app/api/tree/[rootId]/route.ts
+++ b/src/app/api/tree/[rootId]/route.ts
@@ -3,7 +3,6 @@ import { FlowNode, FlowEdge, TreeResponse, PersonData, UnionData } from '@/types
 
 export const runtime = 'nodejs'
 
-const RELATIONSHIP_FILTER = 'UNION>|CHILD>'
 const MAX_TREE_DEPTH = 8
 const MAX_NODES = 500
 const UNION_LABEL = 'Union'
@@ -35,25 +34,31 @@ export async function GET(
   try {
     rows = await read<{ nodes: Neo4jNode[]; rels: Neo4jRel[] }>(
       `MATCH (root:Person {gedcomId: $id})
-       CALL apoc.path.subgraphAll(root, {
-         relationshipFilter: $relationshipFilter,
-         maxLevel: $maxLevel
-       }) YIELD nodes, relationships
-       WITH nodes[0..$maxNodes] AS nodes, relationships
-       RETURN [n IN nodes | CASE
-         WHEN 'Person' IN labels(n) THEN
-           {_id: elementId(n), _labels: labels(n), name: n.name, sex: n.sex,
-            birthYear: n.birthYear, deathYear: n.deathYear, gedcomId: n.gedcomId}
+       OPTIONAL MATCH (root)-[:UNION|CHILD*1..4]->(desc)
+       OPTIONAL MATCH (anc)-[:UNION|CHILD*1..4]->(root)
+       WITH root, collect(DISTINCT desc) AS descendants, collect(DISTINCT anc) AS ancestors
+       WITH [root] + descendants + ancestors AS allNodes
+       CALL (allNodes) {
+         UNWIND allNodes AS n
+         MATCH (n)-[r:UNION|CHILD]->(m)
+         WHERE m IN allNodes
+         RETURN collect(DISTINCT r) AS allRels
+       }
+       WITH allNodes[0..$maxNodes] AS nodes, allRels
+       RETURN [nd IN nodes | CASE
+         WHEN 'Person' IN labels(nd) THEN
+           {_id: elementId(nd), _labels: labels(nd), name: nd.name, sex: nd.sex,
+            birthYear: nd.birthYear, deathYear: nd.deathYear, gedcomId: nd.gedcomId}
          ELSE
-           {_id: elementId(n), _labels: labels(n), gedcomId: n.gedcomId}
+           {_id: elementId(nd), _labels: labels(nd), gedcomId: nd.gedcomId}
         END] AS nodes,
-              [r IN relationships | {
+              [r IN allRels | {
                 _id:   elementId(r),
                 type:  type(r),
                 start: elementId(startNode(r)),
                 end:   elementId(endNode(r))
               }] AS rels`,
-      { id: rootId, relationshipFilter: RELATIONSHIP_FILTER, maxLevel: MAX_TREE_DEPTH, maxNodes: MAX_NODES }
+      { id: rootId, maxNodes: MAX_NODES }
     )
   } catch (err) {
     console.error('Neo4j query failed', err)
@@ -86,7 +91,7 @@ export async function GET(
     id: r._id,
     source: r.start,
     target: r.end,
-    label: r.type,
+    relType: r.type,
   }))
 
   return Response.json({ nodes: flowNodes, edges: flowEdges } satisfies TreeResponse)

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -46,7 +46,9 @@ function FlowCanvas({ rootId, onSelectRoot }: { rootId: string; onSelectRoot: (i
       const rawNodes: Node[] = data.nodes.map((n) => ({
         id: n.id,
         type: n.type,
-        data: n.data,
+        data: n.type === 'person'
+          ? { ...n.data, isRoot: (n.data as import('@/types/tree').PersonData).gedcomId === rootId }
+          : n.data,
         position: n.position,
       }))
 

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
+import type React from 'react'
 import ReactFlow, {
   Background,
   BackgroundVariant,
@@ -21,9 +22,14 @@ import type { TreeResponse } from '@/types/tree'
 
 const nodeTypes = { person: PersonNode, union: UnionNode }
 
+const EDGE_STYLES: Record<string, React.CSSProperties> = {
+  UNION: { stroke: '#6366f1', strokeWidth: 1.5, opacity: 0.6 },
+  CHILD: { stroke: '#a78bfa', strokeWidth: 1, opacity: 0.45 },
+}
+const defaultEdgeStyle = { stroke: '#6366f1', strokeWidth: 1.5, opacity: 0.5 }
+
 const defaultEdgeOptions = {
   type: 'smoothstep',
-  style: { stroke: '#6366f1', strokeWidth: 1.5, opacity: 0.5 },
   animated: false,
 }
 
@@ -56,7 +62,7 @@ function FlowCanvas({ rootId, onSelectRoot }: { rootId: string; onSelectRoot: (i
         id: e.id,
         source: e.source,
         target: e.target,
-        label: e.label,
+        style: EDGE_STYLES[e.relType] ?? defaultEdgeStyle,
       }))
 
       const laid = applyDagreLayout(rawNodes, rawEdges)

--- a/src/components/PersonNode.tsx
+++ b/src/components/PersonNode.tsx
@@ -10,6 +10,9 @@ const SEX_GLOW: Record<string, string> = {
 
 export default function PersonNode({ data }: NodeProps<PersonData>) {
   const glow = SEX_GLOW[data.sex] ?? 'shadow-[0_0_20px_rgba(148,163,184,0.3)]'
+  const rootRing = data.isRoot
+    ? 'ring-2 ring-amber-400 ring-offset-2 ring-offset-transparent shadow-[0_0_28px_rgba(251,191,36,0.6)]'
+    : ''
 
   const dates = [
     data.birthYear ? `b. ${data.birthYear}` : null,
@@ -20,7 +23,7 @@ export default function PersonNode({ data }: NodeProps<PersonData>) {
 
   return (
     <div
-      className={`bg-white/10 backdrop-blur-md border border-white/20 rounded-xl px-4 py-3 min-w-[160px] ${glow} hover:bg-white/15 hover:scale-[1.03] transition-all duration-200`}
+      className={`bg-white/10 backdrop-blur-md border border-white/20 rounded-xl px-4 py-3 min-w-[160px] ${glow} ${rootRing} hover:bg-white/15 hover:scale-[1.03] transition-all duration-200`}
     >
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
       <div className="font-semibold text-white text-sm tracking-wide">{data.name}</div>

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -11,7 +11,7 @@ import { Node, Edge } from 'reactflow'
  *
  * Automatically calculates positions for all nodes in the family tree using a top-to-bottom
  * hierarchical layout algorithm. Person nodes are sized at 160x68, while union nodes are 12x12.
- * The layout respects rank separation (100) and node separation (60) for clear visual hierarchy.
+ * The layout respects rank separation (80) and node separation (40) for clear visual hierarchy.
  *
  * @param {Node[]} nodes - The React Flow nodes to position
  * @param {Edge[]} edges - The React Flow edges defining the graph structure
@@ -20,7 +20,7 @@ import { Node, Edge } from 'reactflow'
 export function applyDagreLayout(nodes: Node[], edges: Edge[]) {
   const g = new dagre.graphlib.Graph()
   g.setDefaultEdgeLabel(() => ({}))
-  g.setGraph({ rankdir: 'TB', ranksep: 100, nodesep: 60 })
+  g.setGraph({ rankdir: 'TB', ranksep: 80, nodesep: 40 })
 
   nodes.forEach(n => {
     const w = n.type === 'union' ? 12 : 160

--- a/src/types/tree.ts
+++ b/src/types/tree.ts
@@ -4,6 +4,7 @@ export interface PersonData {
   sex: string
   birthYear: string | null
   deathYear: string | null
+  isRoot?: boolean
 }
 
 export interface UnionData {

--- a/src/types/tree.ts
+++ b/src/types/tree.ts
@@ -22,7 +22,7 @@ export interface FlowEdge {
   id: string
   source: string
   target: string
-  label: string
+  relType: string
 }
 
 export interface TreeResponse {


### PR DESCRIPTION
Closes #21

## Summary
- **Ancestor traversal**: Cypher query now collects ancestors (up to 4 hops back via reverse `UNION|CHILD` traversal) alongside descendants — both halves of the family tree are visible simultaneously
- **Compact layout**: Dagre ranksep reduced 100→80, nodesep 60→40 so more nodes fit in the default viewport
- **Colour-coded edges**: Removed `UNION`/`CHILD` text label boxes; UNION partnerships render in indigo, CHILD relationships in lighter violet
- **Root person highlight**: Selected/root person gets an amber glow ring so the focal point is always clear in a busy tree

## Test plan
- [ ] Search for a person with known parents — ancestors should appear above them in the graph
- [ ] Search for a person with children — descendants appear below
- [ ] Confirm no "CHILD" or "UNION" text label boxes appear on any edges
- [ ] Confirm the selected root person has an amber ring visible among surrounding nodes
- [ ] Verify `npx tsc --noEmit` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)