### PR TITLE
fix(issue-12): deploy to Vercel with Neo4j Aura

### DIFF
--- a/scripts/import-gedcom.ts
+++ b/scripts/import-gedcom.ts
@@ -56,10 +56,16 @@ if (fs.existsSync(envPath)) {
  * @property {string} [value] - The value associated with this node
  * @property {GedNode[]} children - Child nodes in the GEDCOM hierarchy
  */
+interface GedNodeData {
+  xref_id?: string
+  pointer?: string
+  formal_name?: string
+  [key: string]: unknown
+}
+
 interface GedNode {
   type: string
-  xref_id?: string
-  data?: string
+  data?: GedNodeData
   value?: string
   children: GedNode[]
 }
@@ -114,7 +120,7 @@ async function main() {
     // Batch-build person rows
     const personRows: { gedcomId: string; name: string; sex: string; birthYear: string | null; deathYear: string | null }[] = []
     for (const indi of root.children.filter(r => r.type === GEDCOM_TYPES.INDIVIDUAL)) {
-      if (!indi.xref_id) {
+      if (!indi.data?.xref_id) {
         console.warn('Skipping INDI record without xref_id')
         continue
       }
@@ -124,7 +130,7 @@ async function main() {
       const givenName = childValue(nameNode?.children ?? [], GEDCOM_TYPES.GIVEN_NAME)
       const surname = childValue(nameNode?.children ?? [], GEDCOM_TYPES.SURNAME)
       personRows.push({
-        gedcomId: indi.xref_id,
+        gedcomId: indi.data.xref_id,
         name: [givenName, surname].filter(Boolean).join(' '),
         sex: childValue(indi.children, GEDCOM_TYPES.SEX),
         birthYear: childValue(birthNode?.children ?? [], GEDCOM_TYPES.DATE).match(/\d{4}/)?.[0] ?? null,
@@ -151,18 +157,18 @@ async function main() {
     const childRows: { pid: string; uid: string }[] = []
 
     for (const fam of families) {
-      if (!fam.xref_id) {
+      if (!fam.data?.xref_id) {
         console.warn('Skipping FAM record without xref_id')
         continue
       }
-      const uid = fam.xref_id
+      const uid = fam.data.xref_id
       unionRows.push({ gedcomId: uid })
-      const husb = findChild(fam.children, GEDCOM_TYPES.HUSBAND)?.data
-      const wife = findChild(fam.children, GEDCOM_TYPES.WIFE)?.data
+      const husb = findChild(fam.children, GEDCOM_TYPES.HUSBAND)?.data?.pointer
+      const wife = findChild(fam.children, GEDCOM_TYPES.WIFE)?.data?.pointer
       if (husb) spouseRows.push({ pid: husb, uid })
       if (wife) spouseRows.push({ pid: wife, uid })
       for (const chil of fam.children.filter(n => n.type === GEDCOM_TYPES.CHILD)) {
-        if (chil.data) childRows.push({ pid: chil.data, uid })
+        if (chil.data?.pointer) childRows.push({ pid: chil.data.pointer, uid })
       }
     }
 


### PR DESCRIPTION
## Summary
- Created Neo4j Aura Free instance (`Irene-GED`, `asia-southeast1`) via Aura API
- Fixed `import-gedcom.ts` — `parse-gedcom` puts `xref_id` at `node.data.xref_id` and pointer refs at `node.data.pointer`, not `node.xref_id`/`node.data` (string)
- Imported 586 persons + 177 unions to Aura
- Set Vercel env vars (`NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`) and deployed
- App is live at https://ged-family-tree.vercel.app

## Remaining manual step
DNS: add `A tree 76.76.21.21` at your DNS registrar (currently Afternic nameservers) to route `tree.grocott.com` to Vercel

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)