### PR TITLE
feat(issue-89): persist declineReason on PendingChange decline

### DIFF
--- a/src/app/api/admin/suggestions/[id]/route.test.ts
+++ b/src/app/api/admin/suggestions/[id]/route.test.ts
@@ -249,6 +249,38 @@ describe('POST /api/admin/suggestions/[id]', () => {
     )
   })
 
+  it('persists declineReason on the PendingChange node when a reason is provided', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockRead.mockResolvedValue([pendingSuggestion])
+    mockWrite.mockResolvedValue([])
+
+    const response = await POST(
+      makeRequest({ action: 'decline', reason: 'Insufficient evidence' }),
+      makeParams('sg-1')
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ success: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('c.declineReason = $reason'),
+      { id: 'sg-1', reason: 'Insufficient evidence' }
+    )
+  })
+
+  it('passes declineReason as null when no reason is provided', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockRead.mockResolvedValue([pendingSuggestion])
+    mockWrite.mockResolvedValue([])
+
+    await POST(makeRequest({ action: 'decline' }), makeParams('sg-1'))
+
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('c.declineReason = $reason'),
+      { id: 'sg-1', reason: null }
+    )
+  })
+
   it('does not modify the person record when declining', async () => {
     mockAuth.mockResolvedValue(ADMIN_SESSION as never)
     mockRead.mockResolvedValue([{

--- a/src/app/api/admin/suggestions/[id]/route.test.ts
+++ b/src/app/api/admin/suggestions/[id]/route.test.ts
@@ -245,7 +245,7 @@ describe('POST /api/admin/suggestions/[id]', () => {
     expect(body).toEqual({ success: true })
     expect(mockWrite).toHaveBeenCalledWith(
       expect.stringContaining("SET c.status = 'declined'"),
-      { id: 'sg-1' }
+      expect.objectContaining({ id: 'sg-1' })
     )
   })
 

--- a/src/app/api/admin/suggestions/[id]/route.ts
+++ b/src/app/api/admin/suggestions/[id]/route.ts
@@ -45,6 +45,8 @@ export async function POST(
     return NextResponse.json({ error: 'action must be "approve" or "decline"' }, { status: 400 })
   }
 
+  const reason = typeof body.reason === 'string' ? body.reason : null
+
   let rows: PendingChangeRow[]
   try {
     rows = await read<PendingChangeRow>(
@@ -134,8 +136,9 @@ export async function POST(
       }
     } else {
       await write(
-        `MATCH (c:PendingChange {id: $id}) SET c.status = 'declined'`,
-        { id }
+        `MATCH (c:PendingChange {id: $id})
+         SET c.status = 'declined', c.declinedAt = datetime(), c.declineReason = $reason`,
+        { id, reason }
       )
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- Persist `declineReason` on `PendingChange` nodes when admin declines a suggestion
- Adds test verifying declineReason is written

Closes #89

## Test plan
- [x] Unit test: declineReason persists on decline
- [ ] Manual verification via admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)