### PR TITLE
feat: revert my own changes (CREATE_PERSON, ADD_RELATIONSHIP, UPDATE_PERSON)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 # orchestrator runtime
 logs/
 status.json
+
+# worktrees
+.worktrees/

--- a/docs/plans/2026-04-23-revert-my-changes-design.md
+++ b/docs/plans/2026-04-23-revert-my-changes-design.md
@@ -1,0 +1,173 @@
+# Revert My Changes — Design
+
+**Goal:** Let a signed-in user undo changes they authored — `CREATE_PERSON`, `ADD_RELATIONSHIP`, `UPDATE_PERSON` — directly from the PersonDrawer, and fix the admin revert endpoint which currently no-ops for `CREATE_PERSON` and `ADD_RELATIONSHIP`.
+
+**Feature branch:** `feature/revert-my-changes`
+
+---
+
+## Background
+
+- The `Change` log (`src/lib/changes.ts`) records every mutation with `authorEmail`, `changeType`, `targetId`, `previousValue`, `newValue`, `status`.
+- The admin page `/admin/changes` calls `POST /api/admin/changes/[id]` with `action='revert'`. That handler only applies real undo logic for `UPDATE_PERSON` (`SET p += $prevValue`); for `CREATE_PERSON` and `ADD_RELATIONSHIP` it just flips `status='reverted'` without undoing the graph mutation (`src/app/api/admin/changes/[id]/route.ts:88-92`).
+- Admin role is determined by `ADMIN_EMAILS` env var (`src/auth.ts:27-34`). Locally: `stephen.grocott@gmail.com`.
+
+---
+
+## Scope
+
+In:
+- Authors can revert their own live `CREATE_PERSON` / `ADD_RELATIONSHIP` / `UPDATE_PERSON` changes.
+- Admins can revert any live change using the same endpoint.
+- Three UI entry points, all inside `PersonDrawer`.
+- Real undo logic for all three change types, shared between the author endpoint and the admin endpoint.
+
+Out:
+- Granular field-level undo within a single `UPDATE_PERSON` (the change is the atomic unit).
+- Bulk "undo all my edits" across persons.
+- Time-limited undo windows.
+
+---
+
+## Authorization
+
+One new endpoint, shared:
+
+```
+POST /api/changes/[id]/revert
+```
+
+Guard:
+
+```ts
+const change = await fetchChange(id)
+if (!change)                   return 404
+if (change.status !== 'live')  return 409  // already reverted/kept
+const isAuthor = change.authorEmail === session.user.email
+const isAdmin  = session.user.role === 'admin'
+if (!isAuthor && !isAdmin)     return 403
+```
+
+The underlying revert logic lives in a new module `src/lib/revert.ts`. The existing admin endpoint (`src/app/api/admin/changes/[id]/route.ts`) is refactored to delegate to `src/lib/revert.ts`, which also fixes its broken `CREATE_PERSON` / `ADD_RELATIONSHIP` paths.
+
+Response shape:
+```ts
+// success
+{ success: true }
+// failure
+{ error: string, conflictingChange?: { kind: 'has-relationships' | 'union-touched' | 'field-updated-later', detail: string } }
+```
+
+---
+
+## Revert semantics
+
+### `CREATE_PERSON`
+- **Block if** the Person has any `[:UNION]->()` or `[:CHILD]->()` edges.
+- **Undo:** `DETACH DELETE` the Person.
+- **Audit:** flip Change `status='reverted'`; also write a new `DELETE_PERSON` audit row with the reverter's email.
+
+### `ADD_RELATIONSHIP`
+`newValue = { type, targetId, unionId }` where `type ∈ {spouse, parent, child}`.
+
+- **Block if** the Union has anything beyond the original shape:
+  - `spouse`: union must have exactly 2 `UNION` edges, 0 `CHILD` edges.
+  - `parent | child`: union must have exactly 1 `UNION` edge, 1 `CHILD` edge.
+  - Any deviation → 409 with `conflictingChange.kind='union-touched'`.
+- **Undo:** `DETACH DELETE` the Union node.
+- **Audit:** flip Change `status='reverted'`.
+
+### `UPDATE_PERSON`
+- **Block if** any later live `UPDATE_PERSON` on the same Person touches any of the same `ALLOWED_PATCH_FIELDS` keys present in this change's `previousValue` → 409 with `conflictingChange.kind='field-updated-later'`.
+- **Undo:** `SET p += $prevValue` for the fields present in `previousValue` (same shape as existing `src/app/api/admin/changes/[id]/route.ts:75-87`).
+- **Audit:** flip Change `status='reverted'`.
+
+---
+
+## UI — PersonDrawer
+
+### New read endpoint
+```
+GET /api/person/[id]/my-changes
+```
+Returns the signed-in user's live changes relevant to this person:
+```ts
+{
+  createChange: Change | null,           // CREATE_PERSON targetId = this person
+  relationshipChanges: Change[],         // ADD_RELATIONSHIP where newValue.unionId is one of this person's unions
+  updateChanges: Change[]                // UPDATE_PERSON targetId = this person, newest first
+}
+```
+Drawer calls this alongside the existing `GET /api/person/[id]` fetch. Keeps the detail endpoint lean.
+
+### Surfaces (in `src/components/FamilyTree.tsx`)
+
+1. **Delete button** — red *Delete this person* at drawer bottom, shown only when `createChange` is non-null.
+   - Disabled (tooltip: "Has relationships — contact an admin") if the loaded person detail shows any parents, siblings, marriages, or children.
+   - Click → confirm dialog → `POST /api/changes/<createChange.id>/revert`.
+   - 200 → close drawer, drop the node from the tree, toast "Person deleted."
+   - 409 → surface the `conflictingChange.detail` message.
+
+2. **Per-marriage remove** — × next to each `<li>` inside `person-drawer-marriages`, visible only when that union's id is in `relationshipChanges`.
+   - Click → confirm "Remove marriage to `<spouse name>`?" → revert → refetch person detail.
+
+3. **Edit-mode "Your edits" list** — collapsible section inside the edit form, one row per `updateChanges` entry (newest first): changed fields, ISO timestamp, Revert button.
+   - Hidden when list is empty.
+   - Revert → confirm → refetch person detail + my-changes.
+
+Failures surface the server error inline using the existing error-message pattern.
+
+---
+
+## Testing
+
+### Unit — `src/lib/revert.test.ts`
+
+| Case | Expected |
+|---|---|
+| `CREATE_PERSON` happy (isolated person) | `DETACH DELETE`, status `reverted` |
+| `CREATE_PERSON` block (has UNION edge) | 409, `conflictingChange.kind='has-relationships'` |
+| `ADD_RELATIONSHIP` spouse happy (2 UNION, 0 CHILD) | union deleted, status flipped |
+| `ADD_RELATIONSHIP` parent/child happy (1 UNION, 1 CHILD) | union deleted, status flipped |
+| `ADD_RELATIONSHIP` spouse block (CHILD added later) | 409, `kind='union-touched'` |
+| `ADD_RELATIONSHIP` parent/child block (extra UNION or CHILD) | 409, `kind='union-touched'` |
+| `UPDATE_PERSON` happy | `SET p += prevValue`, status flipped |
+| `UPDATE_PERSON` block (later update on same field) | 409, `kind='field-updated-later'` |
+
+### Integration — API routes
+
+- `POST /api/changes/[id]/revert`: 401 anon, 403 non-admin on someone else's change, 200 author, 200 admin-on-others, 404 missing, 409 already reverted.
+- `GET /api/person/[id]/my-changes`: filters by `authorEmail === session.user.email`, `status='live'` only, correctly split by changeType, only relationship changes whose `unionId` belongs to this person.
+- Refactored admin endpoint passes existing tests unchanged — proves delegation to `src/lib/revert.ts`.
+
+### E2E — `tests/e2e/my-reverts.spec.ts`
+
+Mock-auth / mock-API pattern from `tests/e2e/add-spouse.spec.ts`.
+
+1. Delete-person: button visible → confirm → drawer closes, node dropped.
+2. Remove-marriage: × visible on my-added union only → confirm → marriage disappears.
+3. Revert-edit: edit mode shows "Your edits" → per-row revert → list shrinks.
+4. Block path: mocked 409 shows conflict detail, no state corruption.
+
+### Regression
+
+One test that the admin revert page still succeeds/409s consistently with the shared logic (i.e. the refactor didn't regress `/admin/changes`).
+
+---
+
+## File impact
+
+New:
+- `src/lib/revert.ts` — shared revert logic
+- `src/lib/revert.test.ts`
+- `src/app/api/changes/[id]/revert/route.ts` + test
+- `src/app/api/person/[id]/my-changes/route.ts` + test
+- `tests/e2e/my-reverts.spec.ts`
+
+Edited:
+- `src/app/api/admin/changes/[id]/route.ts` — delegate to `src/lib/revert.ts`
+- `src/components/FamilyTree.tsx` — three new UI surfaces, my-changes fetch
+- `src/lib/changes.ts` — extend to record `DELETE_PERSON` (no schema change; new changeType value)
+- `src/app/admin/types.ts` — add `DELETE_PERSON` to the union
+
+No schema change in Neo4j, no new properties, no migration required.

--- a/docs/plans/2026-04-23-revert-my-changes.md
+++ b/docs/plans/2026-04-23-revert-my-changes.md
@@ -1,0 +1,581 @@
+# Revert My Changes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let authors (and admins) undo their own `CREATE_PERSON`, `ADD_RELATIONSHIP`, and `UPDATE_PERSON` changes from the PersonDrawer, with three dedicated UI surfaces and a shared revert endpoint. Replaces the broken no-op paths in the existing admin revert handler.
+
+**Architecture:** New `src/lib/revert.ts` centralises the per-`changeType` revert logic (block-if-dependent + undo + status flip). Two new routes — `POST /api/changes/[id]/revert` (shared by authors and admins) and `GET /api/person/[id]/my-changes` — expose it. `src/app/api/admin/changes/[id]/route.ts` is refactored to delegate to the same module. `src/components/FamilyTree.tsx` gains three UI surfaces: delete-person button, per-marriage × remove, and "Your edits" list in edit mode.
+
+**Tech Stack:** Next.js 16 App Router, Neo4j (via `src/lib/neo4j.ts`), NextAuth v5 JWT sessions, React 19, Playwright, Jest.
+
+**Feature Branch:** `feature/revert-my-changes` (already created — worktree at `.worktrees/revert-my-changes`).
+
+**Design reference:** `docs/plans/2026-04-23-revert-my-changes-design.md`.
+
+---
+
+## Task 0: Baseline
+
+**Files:** none
+
+**Step 1: Confirm the worktree is on the right branch**
+
+```bash
+cd /Users/shinytrap/projects/GED/.worktrees/revert-my-changes
+git branch --show-current
+```
+Expected: `feature/revert-my-changes`.
+
+**Step 2: Confirm tests run**
+
+```bash
+set -a; source .env.local; set +a
+npx jest --silent 2>&1 | tail -3
+```
+Expected: 16 pre-existing Neo4j-dependent failures, 154 passing, no new regressions introduced by later tasks.
+
+---
+
+## Task 1: Add `DELETE_PERSON` to allowed change types
+
+**Files:**
+- Modify: `src/app/admin/types.ts`
+- Modify: `src/app/api/suggestions/route.ts:8`
+
+**Step 1: Update the admin UI change-type union**
+
+`src/app/admin/types.ts`:
+```ts
+changeType: 'UPDATE_PERSON' | 'CREATE_PERSON' | 'ADD_RELATIONSHIP' | 'DELETE_PERSON'
+```
+
+**Step 2:** Leave `ALLOWED_CHANGE_TYPES` in `src/app/api/suggestions/route.ts` unchanged — `DELETE_PERSON` is only written by the revert path, never by suggestions. The new changeType intentionally is NOT a valid suggestion type.
+
+**Step 3: Commit**
+
+```bash
+git add src/app/admin/types.ts
+git commit -m "feat(revert): allow DELETE_PERSON in admin change-type union"
+```
+
+---
+
+## Task 2: Scaffold `src/lib/revert.ts` with shared types
+
+**Files:**
+- Create: `src/lib/revert.ts`
+
+**Step 1: Create the module with types only**
+
+```ts
+import { read, write } from '@/lib/neo4j'
+import { recordChange } from '@/lib/changes'
+import { ALLOWED_PATCH_FIELDS } from '@/lib/patches'
+
+export type ConflictKind =
+  | 'has-relationships'
+  | 'union-touched'
+  | 'field-updated-later'
+
+export interface RevertConflict {
+  kind: ConflictKind
+  detail: string
+}
+
+export type RevertOutcome =
+  | { ok: true }
+  | { ok: false; status: 404 | 409; error: string; conflict?: RevertConflict }
+
+export interface ChangeRow {
+  id: string
+  changeType: 'CREATE_PERSON' | 'ADD_RELATIONSHIP' | 'UPDATE_PERSON' | 'DELETE_PERSON'
+  targetId: string
+  previousValue: string | null
+  newValue: string
+  status: string
+  authorEmail: string
+  authorName: string
+  appliedAt: string
+}
+
+export async function revertChange(
+  changeId: string,
+  reverter: { email: string; name: string }
+): Promise<RevertOutcome> {
+  throw new Error('not implemented')
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/lib/revert.ts
+git commit -m "feat(revert): scaffold shared revert module"
+```
+
+---
+
+## Task 3: TDD — `CREATE_PERSON` revert happy path
+
+**Files:**
+- Create: `src/lib/revert.test.ts`
+- Modify: `src/lib/revert.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+jest.mock('@/lib/neo4j', () => ({ read: jest.fn(), write: jest.fn() }))
+jest.mock('@/lib/changes', () => ({ recordChange: jest.fn() }))
+
+import { read, write } from '@/lib/neo4j'
+import { recordChange } from '@/lib/changes'
+import { revertChange } from './revert'
+
+const mockRead = read as jest.MockedFunction<typeof read>
+const mockWrite = write as jest.MockedFunction<typeof write>
+const mockRecord = recordChange as jest.MockedFunction<typeof recordChange>
+
+const REVERTER = { email: 'alice@example.com', name: 'Alice' }
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('revertChange — CREATE_PERSON', () => {
+  it('deletes the Person, flips status=reverted, writes DELETE_PERSON audit', async () => {
+    mockRead
+      // fetch change
+      .mockResolvedValueOnce([{ id: 'c1', changeType: 'CREATE_PERSON', targetId: 'I001',
+        previousValue: null, newValue: JSON.stringify({ name: 'X' }),
+        status: 'live', authorEmail: 'a@b', authorName: 'A', appliedAt: '2026-01-01' }])
+      // check edge count
+      .mockResolvedValueOnce([{ edges: 0 }])
+
+    mockWrite.mockResolvedValue([{ deleted: 1 }])
+    const result = await revertChange('c1', REVERTER)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('DETACH DELETE'),
+      expect.objectContaining({ targetId: 'I001' })
+    )
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining("SET c.status = 'reverted'"),
+      expect.objectContaining({ id: 'c1' })
+    )
+    expect(mockRecord).toHaveBeenCalledWith(
+      'alice@example.com', 'Alice', 'DELETE_PERSON', 'I001',
+      expect.any(Object), expect.any(Object)
+    )
+  })
+})
+```
+
+**Step 2: Run to confirm it fails**
+
+```bash
+set -a; source .env.local; set +a
+npx jest src/lib/revert.test.ts 2>&1 | tail -15
+```
+Expected: FAIL ("not implemented").
+
+**Step 3: Implement the happy path in `src/lib/revert.ts`**
+
+Flesh out `revertChange`: fetch the change; if `changeType === 'CREATE_PERSON'`, run an edge count, `DETACH DELETE` the Person, flip change status, call `recordChange('DELETE_PERSON', …)`. Return `{ ok: true }`.
+
+**Step 4: Run to confirm pass**
+
+```bash
+npx jest src/lib/revert.test.ts 2>&1 | tail -5
+```
+Expected: PASS (1/1).
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/revert.ts src/lib/revert.test.ts
+git commit -m "feat(revert): implement CREATE_PERSON revert happy path"
+```
+
+---
+
+## Task 4: TDD — `CREATE_PERSON` block path
+
+**Step 1: Add failing test**
+
+```ts
+it('returns 409 has-relationships when person has UNION or CHILD edges', async () => {
+  mockRead
+    .mockResolvedValueOnce([{ id: 'c1', changeType: 'CREATE_PERSON', targetId: 'I001',
+      previousValue: null, newValue: '{}', status: 'live',
+      authorEmail: 'a@b', authorName: 'A', appliedAt: '2026-01-01' }])
+    .mockResolvedValueOnce([{ edges: 2 }])
+  const result = await revertChange('c1', REVERTER)
+  expect(result).toEqual(expect.objectContaining({
+    ok: false, status: 409,
+    conflict: { kind: 'has-relationships', detail: expect.stringContaining('relationship') },
+  }))
+  expect(mockWrite).not.toHaveBeenCalled()
+})
+```
+
+**Step 2-3: Fail → implement the early-return path → pass.**
+
+**Step 4: Commit**
+
+```bash
+git commit -am "feat(revert): block CREATE_PERSON revert when person has relationships"
+```
+
+---
+
+## Task 5: TDD — `ADD_RELATIONSHIP` happy + block paths
+
+**Step 1-4: Add four test cases iteratively, failing then implementing:**
+
+1. Spouse happy: union with exactly 2 UNION + 0 CHILD → `DETACH DELETE (u)`, status flips.
+2. Parent/child happy: union with exactly 1 UNION + 1 CHILD → same.
+3. Spouse block: union has a CHILD edge → 409 `union-touched`.
+4. Parent/child block: union has extra UNION or CHILD → 409 `union-touched`.
+
+The Cypher edge-count query:
+```cypher
+MATCH (u:Union {gedcomId: $unionId})
+OPTIONAL MATCH (u)<-[ue:UNION]-()
+OPTIONAL MATCH (u)-[ce:CHILD]->()
+RETURN count(DISTINCT ue) AS unionEdges, count(DISTINCT ce) AS childEdges
+```
+
+Block rule:
+- type='spouse': expect `unionEdges === 2 && childEdges === 0`
+- type='parent'|'child': expect `unionEdges === 1 && childEdges === 1`
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(revert): implement ADD_RELATIONSHIP revert (spouse/parent/child with block rules)"
+```
+
+---
+
+## Task 6: TDD — `UPDATE_PERSON` happy + block
+
+**Step 1-4: Add two test cases:**
+
+1. Happy: `SET p += previousValue` for `ALLOWED_PATCH_FIELDS` keys present in `previousValue`, status flips.
+2. Block: a later live `UPDATE_PERSON` on the same `targetId` whose `newValue` keys overlap with our `previousValue` keys → 409 `field-updated-later`.
+
+Later-change lookup:
+```cypher
+MATCH (c:Change { status: 'live', changeType: 'UPDATE_PERSON', targetId: $targetId })
+WHERE c.appliedAt > $appliedAt AND c.id <> $id
+RETURN c.id AS id, c.newValue AS newValue
+```
+In code: parse each row's `newValue`, return 409 if any of its keys intersects with our `previousValue` keys (filtered to `ALLOWED_PATCH_FIELDS`).
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(revert): implement UPDATE_PERSON revert with later-edit block"
+```
+
+---
+
+## Task 7: TDD — edge cases (not-found, already-reverted)
+
+**Step 1: Add tests**
+
+- `ok: false, status: 404` when the change id doesn't match.
+- `ok: false, status: 409, error: 'Change is not live'` when `status !== 'live'`.
+
+**Step 2-4: Fail → implement → pass.**
+
+**Step 5: Commit**
+
+```bash
+git commit -am "test(revert): cover not-found and already-reverted cases"
+```
+
+---
+
+## Task 8: TDD — `POST /api/changes/[id]/revert`
+
+**Files:**
+- Create: `src/app/api/changes/[id]/revert/route.ts`
+- Create: `src/app/api/changes/[id]/revert/route.test.ts`
+
+**Step 1: Write failing tests** (401 anon, 403 non-author non-admin, 200 author, 200 admin-on-others, 404, 409, shape of response body including `conflictingChange`).
+
+Mock `@/auth`, `@/lib/revert` (so this test is about the route wiring, not the revert logic — that's covered in `revert.test.ts`).
+
+**Step 2: Run — fails** (route doesn't exist).
+
+**Step 3: Implement**
+
+```ts
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { read } from '@/lib/neo4j'
+import { revertChange } from '@/lib/revert'
+
+export const runtime = 'nodejs'
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth()
+  if (!session?.user?.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id } = await params
+
+  // Authorization: fetch authorEmail before delegating
+  const rows = await read<{ authorEmail: string }>(
+    `MATCH (c:Change {id: $id}) RETURN c.authorEmail AS authorEmail`, { id }
+  )
+  if (!rows.length) return NextResponse.json({ error: 'Change not found' }, { status: 404 })
+
+  const isAuthor = rows[0].authorEmail === session.user.email
+  const isAdmin = session.user.role === 'admin'
+  if (!isAuthor && !isAdmin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const result = await revertChange(id, {
+    email: session.user.email,
+    name: session.user.name ?? session.user.email,
+  })
+
+  if (result.ok) return NextResponse.json({ success: true })
+  return NextResponse.json(
+    { error: result.error, conflictingChange: result.conflict },
+    { status: result.status }
+  )
+}
+```
+
+**Step 4: Run tests — pass.**
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/changes/[id]/revert
+git commit -m "feat(revert): add POST /api/changes/[id]/revert endpoint"
+```
+
+---
+
+## Task 9: Refactor admin endpoint to delegate
+
+**Files:**
+- Modify: `src/app/api/admin/changes/[id]/route.ts`
+- Verify: `src/app/api/admin/changes/[id]/route.test.ts` still passes
+
+**Step 1: Write one new failing test in `route.test.ts`**
+
+"admin revert of CREATE_PERSON deletes the Person via lib/revert" — confirms delegation, since the old code silently no-ops.
+
+**Step 2: Refactor the `revert` branch** to delegate to `revertChange(id, { email, name })` from `@/lib/revert`. Keep the `keep` branch unchanged.
+
+```ts
+// inside existing POST handler:
+if (action === 'revert') {
+  const result = await revertChange(id, {
+    email: session.user.email!,
+    name: session.user.name ?? session.user.email!,
+  })
+  if (result.ok) return NextResponse.json({ success: true })
+  return NextResponse.json(
+    { error: result.error, conflictingChange: result.conflict },
+    { status: result.status }
+  )
+}
+```
+
+**Step 3: Run the full admin route test file — all existing + new test pass.**
+
+```bash
+npx jest src/app/api/admin/changes/\\[id\\]/route.test.ts 2>&1 | tail -5
+```
+
+**Step 4: Commit**
+
+```bash
+git commit -am "refactor(revert): admin endpoint delegates to lib/revert (fixes no-op CREATE_PERSON/ADD_RELATIONSHIP revert)"
+```
+
+---
+
+## Task 10: TDD — `GET /api/person/[id]/my-changes`
+
+**Files:**
+- Create: `src/app/api/person/[id]/my-changes/route.ts`
+- Create: `src/app/api/person/[id]/my-changes/route.test.ts`
+
+**Step 1: Write failing tests**
+
+- 401 anon.
+- 200 with empty `{ createChange: null, relationshipChanges: [], updateChanges: [] }` when signed-in user has no changes on this person.
+- 200 with populated structure when mock `read` returns a mix of change rows; assert correct split by `changeType`.
+- Assert the query filters by `authorEmail = session.user.email` and `status = 'live'`.
+- Assert relationshipChanges only include changes whose `newValue.unionId` is one of this person's unions (via the query's `WHERE` clause).
+
+**Step 2: Implement the route.** Single Cypher query:
+```cypher
+MATCH (p:Person {gedcomId: $id})
+OPTIONAL MATCH (p)-[:UNION]->(u:Union)
+WITH p, collect(DISTINCT u.gedcomId) AS unionIds
+MATCH (c:Change { status: 'live', authorEmail: $email })
+WHERE
+  (c.changeType = 'CREATE_PERSON'  AND c.targetId = p.gedcomId) OR
+  (c.changeType = 'UPDATE_PERSON'  AND c.targetId = p.gedcomId) OR
+  (c.changeType = 'ADD_RELATIONSHIP' AND
+    apoc.convert.fromJsonMap(c.newValue).unionId IN unionIds)   -- OR equivalent JSON parse
+RETURN c { .* } AS change
+ORDER BY c.appliedAt DESC
+```
+If Aura doesn't have APOC, do the JSON parsing in Node: query ADD_RELATIONSHIP rows separately and filter in JS.
+
+**Step 3-4:** Run tests; fail → pass.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(revert): add GET /api/person/[id]/my-changes"
+```
+
+---
+
+## Task 11: UI — delete-person button in PersonDrawer
+
+**Files:**
+- Modify: `src/components/FamilyTree.tsx`
+- Create: `tests/e2e/revert-delete-person.spec.ts`
+
+**Step 1: Write Playwright E2E test** (copy mock-auth pattern from `tests/e2e/add-spouse.spec.ts`):
+
+Scenarios:
+1. Button visible + clickable when `my-changes` returns a `createChange` AND the person detail has no parents/siblings/marriages. Click → confirm → drawer closes, `fetch` POST to `/api/changes/<id>/revert` observed.
+2. Button disabled with tooltip when person has relationships.
+3. Button absent when `createChange` is null.
+4. 409 from the revert endpoint surfaces the `conflictingChange.detail` message in the drawer.
+
+**Step 2: Run — test fails** (button doesn't exist).
+
+**Step 3: Implement in `FamilyTree.tsx`**
+
+- Add `useEffect` fetching `/api/person/<id>/my-changes` into a new `myChanges` state, re-running when `detailVersion` changes.
+- In view mode, append a red "Delete this person" button after the existing action buttons. Shown only when `myChanges?.createChange`. Disabled when the detail has any parents, siblings, marriages, or children. Tooltip on disabled state.
+- Click → `window.confirm('Delete <name>? This cannot be undone.')` → `fetch` POST; on 200 close drawer + trigger refresh of tree; on 409 setActionError with the `conflictingChange.detail`.
+
+**Step 4: Run tests — pass.**
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(revert): add delete-person button to PersonDrawer"
+```
+
+---
+
+## Task 12: UI — per-marriage × remove button
+
+**Files:**
+- Modify: `src/components/FamilyTree.tsx`
+- Create: `tests/e2e/revert-remove-marriage.spec.ts`
+
+**Step 1: Write Playwright E2E test.** Scenarios:
+
+1. × icon visible only on marriages whose `unionId` appears in `myChanges.relationshipChanges`.
+2. Click × → confirm → marriage disappears; POST to `/api/changes/<id>/revert` observed.
+3. Mocked 409 surfaces the detail.
+
+**Step 2: Fails.**
+
+**Step 3: Implement.** Render a small button next to each `<li>` in `person-drawer-marriages`. Handler: `window.confirm` → POST → on 200 refetch both person detail and `my-changes`.
+
+**Step 4-5:** Pass, commit.
+
+```bash
+git commit -am "feat(revert): add per-marriage remove button to PersonDrawer"
+```
+
+---
+
+## Task 13: UI — "Your edits" list in edit mode
+
+**Files:**
+- Modify: `src/components/FamilyTree.tsx`
+- Create: `tests/e2e/revert-edit-list.spec.ts`
+
+**Step 1: Write E2E test.** Scenarios:
+
+1. Edit mode shows a "Your edits to this person" section only when `myChanges.updateChanges.length > 0`; rows show changed fields + ISO timestamp + Revert.
+2. Revert click → confirm → row disappears; POST observed.
+3. Mocked 409 surfaces `conflictingChange.detail`.
+
+**Step 2: Fails.**
+
+**Step 3: Implement.** Inside the existing edit form, below the field inputs, render a collapsible `<section>` iterating `myChanges.updateChanges`. Each row: comma-joined list of keys in the change's `newValue`, `appliedAt` formatted short, Revert button.
+
+**Step 4-5:** Pass, commit.
+
+```bash
+git commit -am "feat(revert): add Your Edits revert list in PersonDrawer edit mode"
+```
+
+---
+
+## Task 14: Final verification + PR prep
+
+**Step 1: Run the full test suite**
+
+```bash
+set -a; source .env.local; set +a
+npx jest --silent 2>&1 | tail -3
+```
+Expected: the 16 pre-existing Neo4j-env failures; all new unit tests + route tests passing; total pass count higher than baseline by at least the number of new tests we added.
+
+**Step 2: Run Playwright**
+
+```bash
+npx playwright test 2>&1 | tail -10
+```
+Expected: all existing E2E + three new revert specs pass.
+
+**Step 3: Manual smoke check via dev server**
+
+Start `npm run dev` on a free port (not 3000, which is in use). Visit `/?rootId=%40I506%40`, open Donald Grocott drawer, confirm:
+- No delete button (he wasn't created by session user).
+- No × next to marriages.
+- No "Your edits" section in edit mode (no updates by session user).
+
+Then sign in, create a test person via the existing add-relative flow, and confirm all three surfaces appear and function end-to-end. Don't leave test persons in prod Neo4j — revert them via the new button before finishing.
+
+**Step 4: Push branch and open PR**
+
+```bash
+git push -u origin feature/revert-my-changes
+gh pr create --title "feat: revert my own changes (CREATE_PERSON, ADD_RELATIONSHIP, UPDATE_PERSON)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `POST /api/changes/[id]/revert` shared by authors and admins.
+- New `GET /api/person/[id]/my-changes` for drawer surfaces.
+- Three PersonDrawer surfaces: delete-person, per-marriage remove, Your Edits list.
+- Extracts revert logic to `src/lib/revert.ts`; fixes admin no-op revert for CREATE_PERSON / ADD_RELATIONSHIP.
+
+## Test plan
+- [x] Unit: `src/lib/revert.test.ts` covers happy + block paths for all three change types.
+- [x] Integration: route tests for `/api/changes/[id]/revert`, `/api/person/[id]/my-changes`, and refactored admin endpoint.
+- [x] E2E: three new Playwright specs covering the drawer surfaces, including 409 conflict display.
+- [x] Manual: dev-server verified against real Neo4j.
+
+Design: `docs/plans/2026-04-23-revert-my-changes-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 5: Commit the plan itself**
+
+```bash
+git add docs/plans/2026-04-23-revert-my-changes.md
+git commit -m "docs(revert): implementation plan"
+```

--- a/src/app/admin/types.ts
+++ b/src/app/admin/types.ts
@@ -1,6 +1,6 @@
 export interface Change {
   id: string
-  changeType: 'UPDATE_PERSON' | 'CREATE_PERSON' | 'ADD_RELATIONSHIP'
+  changeType: 'UPDATE_PERSON' | 'CREATE_PERSON' | 'ADD_RELATIONSHIP' | 'DELETE_PERSON'
   targetId: string
   personName: string
   authorName: string

--- a/src/app/api/admin/changes/[id]/route.test.ts
+++ b/src/app/api/admin/changes/[id]/route.test.ts
@@ -9,12 +9,19 @@ jest.mock('@/auth', () => ({
   auth: jest.fn(),
 }))
 
+jest.mock('@/lib/revert', () => ({
+  revertChange: jest.fn(),
+}))
+
 import { read, write } from '@/lib/neo4j'
 const mockRead = read as jest.MockedFunction<typeof read>
 const mockWrite = write as jest.MockedFunction<typeof write>
 
 import { auth } from '@/auth'
 const mockAuth = auth as jest.MockedFunction<typeof auth>
+
+import { revertChange } from '@/lib/revert'
+const mockRevert = revertChange as jest.MockedFunction<typeof revertChange>
 
 const ADMIN_SESSION = { user: { email: 'admin@example.com', name: 'Admin', role: 'admin' } }
 const USER_SESSION = { user: { email: 'user@example.com', name: 'User', role: 'user' } }
@@ -30,8 +37,6 @@ const makeParams = (id: string) => ({ params: Promise.resolve({ id }) })
 
 const liveChange = {
   id: 'change-1',
-  targetId: 'I001',
-  previousValue: null,
   status: 'live',
 }
 
@@ -142,77 +147,10 @@ describe('POST /api/admin/changes/[id]', () => {
       expect.stringContaining("SET c.status = 'kept'"),
       { id: 'change-1' }
     )
+    expect(mockRevert).not.toHaveBeenCalled()
   })
 
-  it('returns 200 and reverts person fields when action is revert with a previousValue object', async () => {
-    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
-    const prev = { name: 'Old Name', occupation: 'Farmer', notes: 'Old notes' }
-    mockRead.mockResolvedValue([{ ...liveChange, previousValue: prev }])
-    mockWrite.mockResolvedValue([])
-
-    const response = await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ success: true })
-    expect(mockWrite).toHaveBeenCalledWith(
-      expect.stringContaining("SET p += $prevValue"),
-      expect.objectContaining({ id: 'change-1', prevValue: prev })
-    )
-  })
-
-  it('returns 200 and reverts person fields when previousValue is a JSON string', async () => {
-    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
-    const prev = { name: 'Old Name', birthYear: '1900' }
-    mockRead.mockResolvedValue([{ ...liveChange, previousValue: JSON.stringify(prev) }])
-    mockWrite.mockResolvedValue([])
-
-    const response = await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ success: true })
-    expect(mockWrite).toHaveBeenCalledWith(
-      expect.stringContaining("SET p += $prevValue"),
-      expect.objectContaining({ id: 'change-1', prevValue: prev })
-    )
-  })
-
-  it('strips disallowed fields from previousValue during revert', async () => {
-    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
-    const prev = { name: 'Old Name', password: 'secret', admin: true }
-    mockRead.mockResolvedValue([{ ...liveChange, previousValue: prev }])
-    mockWrite.mockResolvedValue([])
-
-    await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
-
-    const callArgs = (mockWrite as jest.Mock).mock.calls[0][1] as { prevValue: Record<string, unknown> }
-    expect(callArgs.prevValue).not.toHaveProperty('password')
-    expect(callArgs.prevValue).not.toHaveProperty('admin')
-    expect(callArgs.prevValue).toHaveProperty('name', 'Old Name')
-  })
-
-  it('returns 200 and sets status to reverted without touching person when previousValue is null', async () => {
-    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
-    mockRead.mockResolvedValue([{ ...liveChange, previousValue: null }])
-    mockWrite.mockResolvedValue([])
-
-    const response = await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ success: true })
-    expect(mockWrite).toHaveBeenCalledWith(
-      expect.stringContaining("SET c.status = 'reverted'"),
-      { id: 'change-1' }
-    )
-    expect(mockWrite).not.toHaveBeenCalledWith(
-      expect.stringContaining("SET p += $prevValue"),
-      expect.anything()
-    )
-  })
-
-  it('returns 500 when the Neo4j write throws', async () => {
+  it('returns 500 when the Neo4j write throws on keep action', async () => {
     mockAuth.mockResolvedValue(ADMIN_SESSION as never)
     mockRead.mockResolvedValue([liveChange])
     mockWrite.mockRejectedValue(new Error('Write failed'))
@@ -236,5 +174,62 @@ describe('POST /api/admin/changes/[id]', () => {
       expect.stringContaining('MATCH (c:Change {id: $id})'),
       { id: 'change-99' }
     )
+  })
+
+  describe('revert action delegation', () => {
+    it('delegates to revertChange with the change id and reverter derived from the admin session', async () => {
+      mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+      mockRead.mockResolvedValue([liveChange])
+      mockRevert.mockResolvedValue({ ok: true })
+
+      const response = await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true })
+      expect(mockRevert).toHaveBeenCalledWith('change-1', {
+        email: 'admin@example.com',
+        name: 'Admin',
+      })
+    })
+
+    it('surfaces 409 conflict from revertChange with conflictingChange payload', async () => {
+      mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+      mockRead.mockResolvedValue([liveChange])
+      const conflict = {
+        kind: 'has-relationships' as const,
+        detail: 'Person has 2 relationship(s); remove them before reverting.',
+      }
+      mockRevert.mockResolvedValue({
+        ok: false,
+        status: 409,
+        error: 'Cannot revert: person has relationships',
+        conflict,
+      })
+
+      const response = await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body).toEqual({
+        error: 'Cannot revert: person has relationships',
+        conflictingChange: conflict,
+      })
+    })
+
+    it('falls back to email for name when session has no name', async () => {
+      mockAuth.mockResolvedValue({
+        user: { email: 'noname@example.com', role: 'admin' },
+      } as never)
+      mockRead.mockResolvedValue([liveChange])
+      mockRevert.mockResolvedValue({ ok: true })
+
+      await POST(makeRequest({ action: 'revert' }), makeParams('change-1'))
+
+      expect(mockRevert).toHaveBeenCalledWith('change-1', {
+        email: 'noname@example.com',
+        name: 'noname@example.com',
+      })
+    })
   })
 })

--- a/src/app/api/admin/changes/[id]/route.ts
+++ b/src/app/api/admin/changes/[id]/route.ts
@@ -1,21 +1,13 @@
 import { NextResponse } from 'next/server'
 import { read, write } from '@/lib/neo4j'
 import { auth } from '@/auth'
-import { ALLOWED_PATCH_FIELDS } from '@/lib/patches'
+import { revertChange } from '@/lib/revert'
 
 export const runtime = 'nodejs'
 
 interface ChangeRow {
   id: string
-  targetId: string
-  previousValue: string | null
   status: string
-}
-
-function safeParseJson(val: unknown): Record<string, unknown> | null {
-  if (val === null || val === undefined) return null
-  if (typeof val === 'object') return val as Record<string, unknown>
-  try { return JSON.parse(val as string) } catch { return null }
 }
 
 export async function POST(
@@ -48,8 +40,7 @@ export async function POST(
   try {
     rows = await read<ChangeRow>(
       `MATCH (c:Change {id: $id})
-       RETURN c.id AS id, c.targetId AS targetId,
-              c.previousValue AS previousValue, c.status AS status`,
+       RETURN c.id AS id, c.status AS status`,
       { id }
     )
   } catch (err) {
@@ -66,35 +57,27 @@ export async function POST(
     return NextResponse.json({ error: 'Change is not pending review' }, { status: 409 })
   }
 
-  try {
-    if (action === 'keep') {
+  if (action === 'keep') {
+    try {
       await write(
         `MATCH (c:Change {id: $id}) SET c.status = 'kept'`,
         { id }
       )
-    } else if (change.previousValue) {
-      const rawPrev = safeParseJson(change.previousValue) ?? {}
-      const prevValue: Record<string, unknown> = {}
-      for (const key of ALLOWED_PATCH_FIELDS) {
-        if (key in rawPrev) prevValue[key] = rawPrev[key]
-      }
-      await write(
-        `MATCH (c:Change {id: $id})
-         MATCH (p:Person {gedcomId: c.targetId})
-         SET p += $prevValue
-         SET c.status = 'reverted'`,
-        { id, prevValue }
-      )
-    } else {
-      await write(
-        `MATCH (c:Change {id: $id}) SET c.status = 'reverted'`,
-        { id }
-      )
+    } catch (err) {
+      console.error('Neo4j write failed', err)
+      return NextResponse.json({ error: 'Failed to update graph database' }, { status: 500 })
     }
-  } catch (err) {
-    console.error('Neo4j write failed', err)
-    return NextResponse.json({ error: 'Failed to update graph database' }, { status: 500 })
+    return NextResponse.json({ success: true })
   }
 
-  return NextResponse.json({ success: true })
+  const email = session.user.email ?? 'anonymous'
+  const name = session.user.name ?? email
+  const result = await revertChange(id, { email, name })
+  if (result.ok) {
+    return NextResponse.json({ success: true })
+  }
+  return NextResponse.json(
+    { error: result.error, conflictingChange: result.conflict },
+    { status: result.status }
+  )
 }

--- a/src/app/api/changes/[id]/revert/route.test.ts
+++ b/src/app/api/changes/[id]/revert/route.test.ts
@@ -1,0 +1,172 @@
+import { POST } from './route'
+
+jest.mock('@/lib/neo4j', () => ({
+  read: jest.fn(),
+  write: jest.fn(),
+}))
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}))
+
+jest.mock('@/lib/revert', () => ({
+  revertChange: jest.fn(),
+}))
+
+import { read } from '@/lib/neo4j'
+const mockRead = read as jest.MockedFunction<typeof read>
+
+import { auth } from '@/auth'
+const mockAuth = auth as jest.MockedFunction<typeof auth>
+
+import { revertChange } from '@/lib/revert'
+const mockRevert = revertChange as jest.MockedFunction<typeof revertChange>
+
+const AUTHOR_SESSION = {
+  user: { email: 'author@example.com', name: 'Author', role: 'user' },
+}
+const OTHER_USER_SESSION = {
+  user: { email: 'user@example.com', name: 'User', role: 'user' },
+}
+const ADMIN_SESSION = {
+  user: { email: 'admin@example.com', name: 'Admin', role: 'admin' },
+}
+
+const makeRequest = () =>
+  new Request('http://localhost/api/changes/change-1/revert', {
+    method: 'POST',
+  })
+
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) })
+
+describe('POST /api/changes/[id]/revert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 when there is no session', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toEqual({ error: 'Unauthorized' })
+    expect(mockRead).not.toHaveBeenCalled()
+    expect(mockRevert).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the change does not exist', async () => {
+    mockAuth.mockResolvedValue(AUTHOR_SESSION as never)
+    mockRead.mockResolvedValue([])
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: 'Change not found' })
+    expect(mockRevert).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when signed-in user is neither author nor admin', async () => {
+    mockAuth.mockResolvedValue(OTHER_USER_SESSION as never)
+    mockRead.mockResolvedValue([{ authorEmail: 'other@example.com' }])
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body).toEqual({ error: 'Forbidden' })
+    expect(mockRevert).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 when the signed-in user is the author', async () => {
+    mockAuth.mockResolvedValue(AUTHOR_SESSION as never)
+    mockRead.mockResolvedValue([{ authorEmail: 'author@example.com' }])
+    mockRevert.mockResolvedValue({ ok: true })
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ success: true })
+    expect(mockRevert).toHaveBeenCalledWith('change-1', {
+      email: 'author@example.com',
+      name: 'Author',
+    })
+  })
+
+  it('returns 200 when signed-in user is admin acting on someone else\'s change', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockRead.mockResolvedValue([{ authorEmail: 'author@example.com' }])
+    mockRevert.mockResolvedValue({ ok: true })
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ success: true })
+    expect(mockRevert).toHaveBeenCalledWith('change-1', {
+      email: 'admin@example.com',
+      name: 'Admin',
+    })
+  })
+
+  it('returns 409 with conflictingChange when revertChange returns a conflict', async () => {
+    mockAuth.mockResolvedValue(AUTHOR_SESSION as never)
+    mockRead.mockResolvedValue([{ authorEmail: 'author@example.com' }])
+    const conflict = {
+      kind: 'has-relationships' as const,
+      detail: 'Person has 2 relationship(s); remove them before reverting.',
+    }
+    mockRevert.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: 'Cannot revert: person has relationships',
+      conflict,
+    })
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(body).toEqual({
+      error: 'Cannot revert: person has relationships',
+      conflictingChange: conflict,
+    })
+  })
+
+  it('surfaces 404 from revertChange as a 404 response', async () => {
+    mockAuth.mockResolvedValue(AUTHOR_SESSION as never)
+    mockRead.mockResolvedValue([{ authorEmail: 'author@example.com' }])
+    mockRevert.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'Change not found',
+    })
+
+    const response = await POST(makeRequest(), makeParams('change-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({
+      error: 'Change not found',
+      conflictingChange: undefined,
+    })
+  })
+
+  it('falls back to the session email when name is missing', async () => {
+    mockAuth.mockResolvedValue({
+      user: { email: 'noname@example.com', role: 'user' },
+    } as never)
+    mockRead.mockResolvedValue([{ authorEmail: 'noname@example.com' }])
+    mockRevert.mockResolvedValue({ ok: true })
+
+    await POST(makeRequest(), makeParams('change-1'))
+
+    expect(mockRevert).toHaveBeenCalledWith('change-1', {
+      email: 'noname@example.com',
+      name: 'noname@example.com',
+    })
+  })
+})

--- a/src/app/api/changes/[id]/revert/route.ts
+++ b/src/app/api/changes/[id]/revert/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { read } from '@/lib/neo4j'
+import { revertChange } from '@/lib/revert'
+
+export const runtime = 'nodejs'
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const rows = await read<{ authorEmail: string }>(
+    `MATCH (c:Change {id: $id}) RETURN c.authorEmail AS authorEmail`,
+    { id }
+  )
+  if (!rows.length) {
+    return NextResponse.json({ error: 'Change not found' }, { status: 404 })
+  }
+
+  const isAuthor = rows[0].authorEmail === session.user.email
+  const isAdmin = session.user.role === 'admin'
+  if (!isAuthor && !isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const result = await revertChange(id, {
+    email: session.user.email,
+    name: session.user.name ?? session.user.email,
+  })
+
+  if (result.ok) {
+    return NextResponse.json({ success: true })
+  }
+  return NextResponse.json(
+    { error: result.error, conflictingChange: result.conflict },
+    { status: result.status }
+  )
+}

--- a/src/app/api/person/[id]/my-changes/route.test.ts
+++ b/src/app/api/person/[id]/my-changes/route.test.ts
@@ -1,0 +1,261 @@
+import { GET } from './route'
+
+jest.mock('@/lib/neo4j', () => ({
+  read: jest.fn(),
+}))
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}))
+
+import { read } from '@/lib/neo4j'
+const mockRead = read as jest.MockedFunction<typeof read>
+
+import { auth } from '@/auth'
+const mockAuth = auth as jest.MockedFunction<typeof auth>
+
+const USER_SESSION = {
+  user: { email: 'user@example.com', name: 'User', role: 'user' },
+}
+
+const makeRequest = () =>
+  new Request('http://localhost/api/person/I001/my-changes')
+
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) })
+
+describe('GET /api/person/[id]/my-changes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 when there is no session', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toEqual({ error: 'Unauthorized' })
+    expect(mockRead).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when session has no email', async () => {
+    mockAuth.mockResolvedValue({ user: { name: 'Anon' } } as never)
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+
+    expect(response.status).toBe(401)
+    expect(mockRead).not.toHaveBeenCalled()
+  })
+
+  it('returns empty result when the user has no changes for this person', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    // First read: unions. Second read: changes.
+    mockRead.mockResolvedValueOnce([])
+    mockRead.mockResolvedValueOnce([])
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      createChange: null,
+      relationshipChanges: [],
+      updateChanges: [],
+    })
+  })
+
+  it('filters by authorEmail and status=live in the change query', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    mockRead.mockResolvedValueOnce([])
+    mockRead.mockResolvedValueOnce([])
+
+    await GET(makeRequest(), makeParams('I001'))
+
+    // Second call is the changes query
+    const secondCall = mockRead.mock.calls[1]
+    expect(secondCall[0]).toMatch(/status:\s*'live'/)
+    expect(secondCall[0]).toMatch(/authorEmail:\s*\$email/)
+    expect(secondCall[1]).toEqual(
+      expect.objectContaining({ email: 'user@example.com', id: 'I001' })
+    )
+  })
+
+  it('splits changes by changeType into the correct categories', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    // Person has one union U100
+    mockRead.mockResolvedValueOnce([{ unionId: 'U100' }])
+    // Three rows: one of each type
+    mockRead.mockResolvedValueOnce([
+      {
+        id: 'c-update',
+        changeType: 'UPDATE_PERSON',
+        targetId: 'I001',
+        newValue: JSON.stringify({ name: 'New Name' }),
+        previousValue: JSON.stringify({ name: 'Old Name' }),
+        appliedAt: '2026-04-22T10:00:00Z',
+      },
+      {
+        id: 'c-rel',
+        changeType: 'ADD_RELATIONSHIP',
+        targetId: 'I001',
+        newValue: JSON.stringify({ unionId: 'U100', type: 'spouse' }),
+        previousValue: null,
+        appliedAt: '2026-04-21T10:00:00Z',
+      },
+      {
+        id: 'c-create',
+        changeType: 'CREATE_PERSON',
+        targetId: 'I001',
+        newValue: JSON.stringify({ name: 'X', sex: 'M' }),
+        previousValue: null,
+        appliedAt: '2026-04-20T10:00:00Z',
+      },
+    ])
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.createChange).toEqual({
+      id: 'c-create',
+      changeType: 'CREATE_PERSON',
+      targetId: 'I001',
+      newValue: { name: 'X', sex: 'M' },
+      previousValue: null,
+      appliedAt: '2026-04-20T10:00:00Z',
+    })
+    expect(body.relationshipChanges).toEqual([
+      {
+        id: 'c-rel',
+        changeType: 'ADD_RELATIONSHIP',
+        targetId: 'I001',
+        newValue: { unionId: 'U100', type: 'spouse' },
+        previousValue: null,
+        appliedAt: '2026-04-21T10:00:00Z',
+      },
+    ])
+    expect(body.updateChanges).toEqual([
+      {
+        id: 'c-update',
+        changeType: 'UPDATE_PERSON',
+        targetId: 'I001',
+        newValue: { name: 'New Name' },
+        previousValue: { name: 'Old Name' },
+        appliedAt: '2026-04-22T10:00:00Z',
+      },
+    ])
+  })
+
+  it('filters out ADD_RELATIONSHIP rows whose unionId is not in this person\'s unions', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    mockRead.mockResolvedValueOnce([{ unionId: 'U100' }])
+    mockRead.mockResolvedValueOnce([
+      {
+        id: 'c-rel-in',
+        changeType: 'ADD_RELATIONSHIP',
+        targetId: 'I001',
+        newValue: JSON.stringify({ unionId: 'U100' }),
+        previousValue: null,
+        appliedAt: '2026-04-21T10:00:00Z',
+      },
+      {
+        id: 'c-rel-out',
+        changeType: 'ADD_RELATIONSHIP',
+        targetId: 'I002',
+        newValue: JSON.stringify({ unionId: 'U999' }),
+        previousValue: null,
+        appliedAt: '2026-04-20T10:00:00Z',
+      },
+    ])
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(body.relationshipChanges).toHaveLength(1)
+    expect(body.relationshipChanges[0].id).toBe('c-rel-in')
+  })
+
+  it('returns updateChanges in newest-first order', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    mockRead.mockResolvedValueOnce([])
+    mockRead.mockResolvedValueOnce([
+      {
+        id: 'c-update-new',
+        changeType: 'UPDATE_PERSON',
+        targetId: 'I001',
+        newValue: JSON.stringify({ name: 'Newer' }),
+        previousValue: null,
+        appliedAt: '2026-04-22T10:00:00Z',
+      },
+      {
+        id: 'c-update-old',
+        changeType: 'UPDATE_PERSON',
+        targetId: 'I001',
+        newValue: JSON.stringify({ name: 'Older' }),
+        previousValue: null,
+        appliedAt: '2026-04-20T10:00:00Z',
+      },
+    ])
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(body.updateChanges.map((c: { id: string }) => c.id)).toEqual([
+      'c-update-new',
+      'c-update-old',
+    ])
+  })
+
+  it('does not crash on malformed JSON in newValue; returns newValue: {}', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    mockRead.mockResolvedValueOnce([])
+    mockRead.mockResolvedValueOnce([
+      {
+        id: 'c-bad',
+        changeType: 'UPDATE_PERSON',
+        targetId: 'I001',
+        newValue: '{not valid json',
+        previousValue: null,
+        appliedAt: '2026-04-22T10:00:00Z',
+      },
+    ])
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.updateChanges).toHaveLength(1)
+    expect(body.updateChanges[0].newValue).toEqual({})
+  })
+
+  it('returns only the newest when multiple CREATE_PERSON rows exist', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    mockRead.mockResolvedValueOnce([])
+    // Rows come back ordered newest-first by the Cypher ORDER BY
+    mockRead.mockResolvedValueOnce([
+      {
+        id: 'c-create-new',
+        changeType: 'CREATE_PERSON',
+        targetId: 'I001',
+        newValue: JSON.stringify({ name: 'Newer' }),
+        previousValue: null,
+        appliedAt: '2026-04-22T10:00:00Z',
+      },
+      {
+        id: 'c-create-old',
+        changeType: 'CREATE_PERSON',
+        targetId: 'I001',
+        newValue: JSON.stringify({ name: 'Older' }),
+        previousValue: null,
+        appliedAt: '2026-04-20T10:00:00Z',
+      },
+    ])
+
+    const response = await GET(makeRequest(), makeParams('I001'))
+    const body = await response.json()
+
+    expect(body.createChange).not.toBeNull()
+    expect(body.createChange.id).toBe('c-create-new')
+  })
+})

--- a/src/app/api/person/[id]/my-changes/route.ts
+++ b/src/app/api/person/[id]/my-changes/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { read } from '@/lib/neo4j'
+
+export const runtime = 'nodejs'
+
+type ChangeType = 'CREATE_PERSON' | 'ADD_RELATIONSHIP' | 'UPDATE_PERSON'
+
+interface ChangeRow {
+  id: string
+  changeType: ChangeType
+  targetId: string
+  newValue: string
+  previousValue: string | null
+  appliedAt: string
+}
+
+interface ShapedChange {
+  id: string
+  changeType: ChangeType
+  targetId: string
+  newValue: Record<string, unknown>
+  previousValue: Record<string, unknown> | null
+  appliedAt: string
+}
+
+function parseJson(val: string | null): Record<string, unknown> | null {
+  if (val == null) return null
+  try {
+    const parsed = JSON.parse(val)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function shape(row: ChangeRow): ShapedChange {
+  return {
+    id: row.id,
+    changeType: row.changeType,
+    targetId: row.targetId,
+    newValue: parseJson(row.newValue) ?? {},
+    previousValue: parseJson(row.previousValue),
+    appliedAt: row.appliedAt,
+  }
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const email = session.user.email
+
+  // Step 1: collect this person's union ids.
+  const unionRows = await read<{ unionId: string }>(
+    `MATCH (p:Person {gedcomId: $id})-[:UNION]->(u:Union)
+     RETURN DISTINCT u.gedcomId AS unionId`,
+    { id }
+  )
+  const unionIds = new Set(unionRows.map(r => r.unionId).filter(Boolean))
+
+  // Step 2: fetch candidate live changes authored by this user.
+  // ADD_RELATIONSHIP is filtered broadly then narrowed to this person's unions in JS,
+  // to avoid needing APOC (not guaranteed on Aura/Neo4j Community).
+  const changeRows = await read<ChangeRow>(
+    `MATCH (c:Change { status: 'live', authorEmail: $email })
+     WHERE (c.changeType IN ['CREATE_PERSON','UPDATE_PERSON'] AND c.targetId = $id)
+        OR c.changeType = 'ADD_RELATIONSHIP'
+     RETURN c.id            AS id,
+            c.changeType    AS changeType,
+            c.targetId      AS targetId,
+            c.newValue      AS newValue,
+            c.previousValue AS previousValue,
+            c.appliedAt     AS appliedAt
+     ORDER BY c.appliedAt DESC`,
+    { email, id }
+  )
+
+  const creates: ShapedChange[] = []
+  const updates: ShapedChange[] = []
+  const rels: ShapedChange[] = []
+
+  for (const row of changeRows) {
+    const shaped = shape(row)
+    if (row.changeType === 'CREATE_PERSON') {
+      creates.push(shaped)
+    } else if (row.changeType === 'UPDATE_PERSON') {
+      updates.push(shaped)
+    } else if (row.changeType === 'ADD_RELATIONSHIP') {
+      const unionId = shaped.newValue.unionId
+      if (typeof unionId === 'string' && unionIds.has(unionId)) {
+        rels.push(shaped)
+      }
+    }
+  }
+
+  return NextResponse.json({
+    createChange: creates[0] ?? null,
+    relationshipChanges: rels,
+    updateChanges: updates,
+  })
+}

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -261,6 +261,12 @@ export function PersonDrawer({
   const [actionError, setActionError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  const [myChanges, setMyChanges] = useState<{
+    createChange: { id: string; changeType: string; targetId: string; newValue: Record<string, unknown>; appliedAt: string } | null
+    relationshipChanges: Array<{ id: string; newValue: Record<string, unknown>; appliedAt: string }>
+    updateChanges: Array<{ id: string; newValue: Record<string, unknown>; appliedAt: string }>
+  } | null>(null)
+
   useEffect(() => {
     setDetail(null)
     setDetailLoading(true)
@@ -280,6 +286,42 @@ export function PersonDrawer({
       .finally(() => { if (!cancelled) setDetailLoading(false) })
     return () => { cancelled = true; ctrl.abort() }
   }, [person.gedcomId, detailVersion])
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/person/${encodeURIComponent(person.gedcomId)}/my-changes`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (cancelled || !data) return
+        // Only accept responses that match the expected shape; guards against
+        // unmocked test environments that might serve arbitrary JSON here.
+        if (Array.isArray(data.relationshipChanges) && Array.isArray(data.updateChanges)) {
+          setMyChanges(data)
+        }
+      })
+      .catch(err => {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          console.error('Failed to fetch my-changes', err)
+        }
+      })
+    return () => { cancelled = true }
+  }, [person.gedcomId, detailVersion])
+
+  /**
+   * Revert a change via POST /api/changes/[id]/revert.
+   * Returns `{ ok: true }` on 2xx or `{ ok: false, detail }` on failure,
+   * pulling a human-readable message from `conflictingChange.detail` or
+   * `error` in the response body.
+   */
+  const revertChangeRequest = async (
+    changeId: string
+  ): Promise<{ ok: true } | { ok: false; detail: string }> => {
+    const res = await fetch(`/api/changes/${encodeURIComponent(changeId)}/revert`, { method: 'POST' })
+    if (res.ok) return { ok: true }
+    const body = await res.json().catch(() => ({}))
+    const detail = body?.conflictingChange?.detail ?? body?.error ?? 'Revert failed'
+    return { ok: false, detail: String(detail) }
+  }
 
   useEffect(() => {
     if (mode !== 'add-relative' || !searchQuery.trim()) {
@@ -383,6 +425,74 @@ export function PersonDrawer({
       setActionError('Failed to create and link person. Please try again.')
     } finally {
       setIsSubmitting(false)
+    }
+  }
+
+  /**
+   * True when the detail record has any relationships (parents, siblings, marriages, or
+   * children within a marriage). Used to disable the delete-person button because a
+   * `CREATE_PERSON` revert is only safe when the Person has no UNION/CHILD edges.
+   */
+  const detailHasRelationships = !!(
+    detail && (
+      detail.parents.length > 0 ||
+      detail.siblings.length > 0 ||
+      detail.marriages.length > 0
+    )
+  )
+
+  /**
+   * Deletes the current person by reverting the author's CREATE_PERSON change.
+   * Only callable when `myChanges.createChange` is present (caller enforces button visibility).
+   * Prompts for confirmation, then on success closes the drawer and refreshes the tree.
+   * On 409 surfaces the server's conflict detail inline via `actionError`.
+   */
+  const handleDeletePerson = async () => {
+    if (!myChanges?.createChange) return
+    if (typeof window !== 'undefined' && !window.confirm(`Delete ${person.name || 'this person'}? This cannot be undone.`)) return
+    const result = await revertChangeRequest(myChanges.createChange.id)
+    if (result.ok) {
+      setMyChanges(null)
+      onSelectRoot?.(person.gedcomId) // nudges tree refetch in the parent canvas
+      onClose()
+    } else {
+      setActionError(result.detail)
+    }
+  }
+
+  /**
+   * Removes a marriage/union by reverting the author's ADD_RELATIONSHIP change for it.
+   * On success, bumps `detailVersion` so both the person detail and `my-changes`
+   * re-fetch (the marriage disappears from the list). On 409 surfaces the detail
+   * inline via `actionError`.
+   * @param {string} changeId - id of the `ADD_RELATIONSHIP` Change to revert
+   */
+  const handleRemoveMarriage = async (changeId: string) => {
+    if (typeof window !== 'undefined' && !window.confirm('Remove this marriage? This cannot be undone.')) return
+    const result = await revertChangeRequest(changeId)
+    if (result.ok) {
+      onSelectRoot?.(person.gedcomId)
+      setDetailVersion(v => v + 1)
+    } else {
+      setActionError(result.detail)
+    }
+  }
+
+  /**
+   * Reverts one of this author's UPDATE_PERSON changes on this person.
+   * On success, bumps `detailVersion` so the "Your edits" list shrinks and the
+   * person detail reflects the restored previousValue. On 409 surfaces the detail
+   * inline via `actionError`.
+   * @param {string} changeId - id of the `UPDATE_PERSON` Change to revert
+   */
+  const handleRevertEdit = async (changeId: string) => {
+    if (typeof window !== 'undefined' && !window.confirm('Revert this edit? The previous values will be restored.')) return
+    const result = await revertChangeRequest(changeId)
+    if (result.ok) {
+      onSelectRoot?.(person.gedcomId)
+      setDetailVersion(v => v + 1)
+    } else {
+      setActionError(result.detail)
     }
   }
 
@@ -615,6 +725,42 @@ export function PersonDrawer({
               + Add notes
             </button>
           )}
+          {myChanges && Array.isArray(myChanges.updateChanges) && myChanges.updateChanges.length > 0 && (
+            <section
+              data-testid="person-drawer-your-edits"
+              className="pt-3 mt-3 border-t border-white/10 space-y-2"
+            >
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                Your edits to this person
+              </h3>
+              <ul className="space-y-2">
+                {myChanges.updateChanges.map(c => (
+                  <li
+                    key={c.id}
+                    data-testid={`your-edit-${c.id}`}
+                    className="flex items-center gap-2 text-xs text-white/70"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <span className="block truncate text-white/80">
+                        {Object.keys(c.newValue).join(', ') || '(no fields)'}
+                      </span>
+                      <time className="block text-[10px] text-slate-500">
+                        {new Date(c.appliedAt).toISOString()}
+                      </time>
+                    </div>
+                    <button
+                      type="button"
+                      data-testid={`your-edit-revert-${c.id}`}
+                      onClick={() => handleRevertEdit(c.id)}
+                      className="px-2 py-1 rounded-lg bg-white/10 hover:bg-white/20 text-xs text-white/80 transition-colors"
+                    >
+                      Revert
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
           {actionError && (
             <p className="text-red-400 text-xs">{actionError}</p>
           )}
@@ -832,16 +978,37 @@ export function PersonDrawer({
                 <p className="text-slate-600 text-xs italic">None recorded</p>
               ) : (
                 <ul className="space-y-3">
-                  {detail.marriages.map(m => (
-                    <li key={m.unionId} className="space-y-1">
-                      {m.spouse && <RelativeRow person={m.spouse} onSelect={onSelectPerson} onReroot={onReroot} />}
-                      {m.children.length > 0 && (
-                        <ul className="pl-4 space-y-1">
-                          {m.children.map(c => <li key={c.gedcomId}><RelativeRow person={c} onSelect={onSelectPerson} onReroot={onReroot} small /></li>)}
-                        </ul>
-                      )}
-                    </li>
-                  ))}
+                  {detail.marriages.map(m => {
+                    const removableChange = myChanges?.relationshipChanges?.find(
+                      c => c.newValue.unionId === m.unionId
+                    )
+                    return (
+                      <li key={m.unionId} className="space-y-1">
+                        <div className="flex items-center gap-1">
+                          <div className="flex-1 min-w-0">
+                            {m.spouse && <RelativeRow person={m.spouse} onSelect={onSelectPerson} onReroot={onReroot} />}
+                          </div>
+                          {removableChange && (
+                            <button
+                              type="button"
+                              data-testid={`marriage-remove-${m.unionId}`}
+                              aria-label="Remove marriage"
+                              title="Remove marriage"
+                              onClick={() => handleRemoveMarriage(removableChange.id)}
+                              className="w-6 h-6 flex items-center justify-center rounded-lg text-white/40 hover:text-red-400 hover:bg-white/10 transition-colors text-sm leading-none flex-shrink-0"
+                            >
+                              ×
+                            </button>
+                          )}
+                        </div>
+                        {m.children.length > 0 && (
+                          <ul className="pl-4 space-y-1">
+                            {m.children.map(c => <li key={c.gedcomId}><RelativeRow person={c} onSelect={onSelectPerson} onReroot={onReroot} small /></li>)}
+                          </ul>
+                        )}
+                      </li>
+                    )
+                  })}
                 </ul>
               )}
               {isSignedIn && (
@@ -874,6 +1041,21 @@ export function PersonDrawer({
         >
           FOCUS TREE ON {(person.name || 'PERSON').toUpperCase()}
         </button>
+        {myChanges?.createChange && (
+          <button
+            data-testid="person-drawer-delete"
+            onClick={handleDeletePerson}
+            disabled={detailHasRelationships}
+            title={detailHasRelationships ? 'Has relationships — contact an admin' : undefined}
+            aria-label={`Delete ${person.name || 'person'}`}
+            className="w-full py-2 rounded-xl bg-red-500/80 hover:bg-red-500 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-red-500/80"
+          >
+            Delete this person
+          </button>
+        )}
+        {actionError && (
+          <p data-testid="person-drawer-action-error" className="text-red-400 text-xs">{actionError}</p>
+        )}
         {!isSignedIn && (
           <button
             onClick={() => signIn('google')}

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -288,14 +288,21 @@ export function PersonDrawer({
   }, [person.gedcomId, detailVersion])
 
   useEffect(() => {
+    setMyChanges(null)
+    const ctrl = new AbortController()
     let cancelled = false
-    fetch(`/api/person/${encodeURIComponent(person.gedcomId)}/my-changes`)
+    fetch(`/api/person/${encodeURIComponent(person.gedcomId)}/my-changes`, { signal: ctrl.signal })
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (cancelled || !data) return
         // Only accept responses that match the expected shape; guards against
         // unmocked test environments that might serve arbitrary JSON here.
-        if (Array.isArray(data.relationshipChanges) && Array.isArray(data.updateChanges)) {
+        if (
+          Array.isArray(data.relationshipChanges) &&
+          Array.isArray(data.updateChanges) &&
+          (data.createChange === null ||
+            (typeof data.createChange === 'object' && typeof data.createChange.id === 'string'))
+        ) {
           setMyChanges(data)
         }
       })
@@ -304,7 +311,7 @@ export function PersonDrawer({
           console.error('Failed to fetch my-changes', err)
         }
       })
-    return () => { cancelled = true }
+    return () => { cancelled = true; ctrl.abort() }
   }, [person.gedcomId, detailVersion])
 
   /**
@@ -429,16 +436,15 @@ export function PersonDrawer({
   }
 
   /**
-   * True when the detail record has any relationships (parents, siblings, marriages, or
-   * children within a marriage). Used to disable the delete-person button because a
-   * `CREATE_PERSON` revert is only safe when the Person has no UNION/CHILD edges.
+   * True when the detail record has direct edges (parents or marriages) on the Person
+   * node. Used to disable the delete-person button because a `CREATE_PERSON` revert is
+   * only safe when the Person has no UNION/CHILD edges. Siblings are intentionally
+   * omitted: they are derived from shared parents, not direct edges on this node, so
+   * they don't block `DETACH DELETE`. The server guard (edge count on the node) is the
+   * source of truth; this local check just pre-disables for obvious cases.
    */
   const detailHasRelationships = !!(
-    detail && (
-      detail.parents.length > 0 ||
-      detail.siblings.length > 0 ||
-      detail.marriages.length > 0
-    )
+    detail && (detail.parents.length > 0 || detail.marriages.length > 0)
   )
 
   /**
@@ -448,15 +454,21 @@ export function PersonDrawer({
    * On 409 surfaces the server's conflict detail inline via `actionError`.
    */
   const handleDeletePerson = async () => {
+    if (isSubmitting) return
     if (!myChanges?.createChange) return
     if (typeof window !== 'undefined' && !window.confirm(`Delete ${person.name || 'this person'}? This cannot be undone.`)) return
-    const result = await revertChangeRequest(myChanges.createChange.id)
-    if (result.ok) {
-      setMyChanges(null)
-      onSelectRoot?.(person.gedcomId) // nudges tree refetch in the parent canvas
-      onClose()
-    } else {
-      setActionError(result.detail)
+    setIsSubmitting(true)
+    try {
+      const result = await revertChangeRequest(myChanges.createChange.id)
+      if (result.ok) {
+        setMyChanges(null)
+        onSelectRoot?.(person.gedcomId) // nudges tree refetch in the parent canvas
+        onClose()
+      } else {
+        setActionError(result.detail)
+      }
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -468,13 +480,19 @@ export function PersonDrawer({
    * @param {string} changeId - id of the `ADD_RELATIONSHIP` Change to revert
    */
   const handleRemoveMarriage = async (changeId: string) => {
+    if (isSubmitting) return
     if (typeof window !== 'undefined' && !window.confirm('Remove this marriage? This cannot be undone.')) return
-    const result = await revertChangeRequest(changeId)
-    if (result.ok) {
-      onSelectRoot?.(person.gedcomId)
-      setDetailVersion(v => v + 1)
-    } else {
-      setActionError(result.detail)
+    setIsSubmitting(true)
+    try {
+      const result = await revertChangeRequest(changeId)
+      if (result.ok) {
+        onSelectRoot?.(person.gedcomId)
+        setDetailVersion(v => v + 1)
+      } else {
+        setActionError(result.detail)
+      }
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -486,13 +504,19 @@ export function PersonDrawer({
    * @param {string} changeId - id of the `UPDATE_PERSON` Change to revert
    */
   const handleRevertEdit = async (changeId: string) => {
+    if (isSubmitting) return
     if (typeof window !== 'undefined' && !window.confirm('Revert this edit? The previous values will be restored.')) return
-    const result = await revertChangeRequest(changeId)
-    if (result.ok) {
-      onSelectRoot?.(person.gedcomId)
-      setDetailVersion(v => v + 1)
-    } else {
-      setActionError(result.detail)
+    setIsSubmitting(true)
+    try {
+      const result = await revertChangeRequest(changeId)
+      if (result.ok) {
+        onSelectRoot?.(person.gedcomId)
+        setDetailVersion(v => v + 1)
+      } else {
+        setActionError(result.detail)
+      }
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -752,7 +776,8 @@ export function PersonDrawer({
                       type="button"
                       data-testid={`your-edit-revert-${c.id}`}
                       onClick={() => handleRevertEdit(c.id)}
-                      className="px-2 py-1 rounded-lg bg-white/10 hover:bg-white/20 text-xs text-white/80 transition-colors"
+                      disabled={isSubmitting}
+                      className="px-2 py-1 rounded-lg bg-white/10 hover:bg-white/20 text-xs text-white/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       Revert
                     </button>
@@ -762,7 +787,7 @@ export function PersonDrawer({
             </section>
           )}
           {actionError && (
-            <p className="text-red-400 text-xs">{actionError}</p>
+            <p data-testid="person-drawer-edit-action-error" className="text-red-400 text-xs">{actionError}</p>
           )}
           <div className="flex gap-2">
             <button
@@ -995,7 +1020,8 @@ export function PersonDrawer({
                               aria-label="Remove marriage"
                               title="Remove marriage"
                               onClick={() => handleRemoveMarriage(removableChange.id)}
-                              className="w-6 h-6 flex items-center justify-center rounded-lg text-white/40 hover:text-red-400 hover:bg-white/10 transition-colors text-sm leading-none flex-shrink-0"
+                              disabled={isSubmitting}
+                              className="w-6 h-6 flex items-center justify-center rounded-lg text-white/40 hover:text-red-400 hover:bg-white/10 transition-colors text-sm leading-none flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                               ×
                             </button>
@@ -1045,7 +1071,7 @@ export function PersonDrawer({
           <button
             data-testid="person-drawer-delete"
             onClick={handleDeletePerson}
-            disabled={detailHasRelationships}
+            disabled={detailHasRelationships || isSubmitting}
             title={detailHasRelationships ? 'Has relationships — contact an admin' : undefined}
             aria-label={`Delete ${person.name || 'person'}`}
             className="w-full py-2 rounded-xl bg-red-500/80 hover:bg-red-500 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-red-500/80"

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -749,7 +749,7 @@ export function PersonDrawer({
               + Add notes
             </button>
           )}
-          {myChanges && Array.isArray(myChanges.updateChanges) && myChanges.updateChanges.length > 0 && (
+          {myChanges && myChanges.updateChanges.length > 0 && (
             <section
               data-testid="person-drawer-your-edits"
               className="pt-3 mt-3 border-t border-white/10 space-y-2"

--- a/src/lib/revert.test.ts
+++ b/src/lib/revert.test.ts
@@ -1,0 +1,57 @@
+jest.mock('@/lib/neo4j', () => ({ read: jest.fn(), write: jest.fn() }))
+jest.mock('@/lib/changes', () => ({ recordChange: jest.fn() }))
+
+import { read, write } from '@/lib/neo4j'
+import { recordChange } from '@/lib/changes'
+import { revertChange } from './revert'
+
+const mockRead = read as jest.MockedFunction<typeof read>
+const mockWrite = write as jest.MockedFunction<typeof write>
+const mockRecord = recordChange as jest.MockedFunction<typeof recordChange>
+
+const REVERTER = { email: 'alice@example.com', name: 'Alice' }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockWrite.mockResolvedValue([])
+})
+
+describe('revertChange — CREATE_PERSON', () => {
+  it('deletes the Person, flips status=reverted, writes DELETE_PERSON audit', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c1',
+          changeType: 'CREATE_PERSON',
+          targetId: 'I001',
+          previousValue: null,
+          newValue: JSON.stringify({ name: 'X' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([{ edges: 0 }])
+
+    const result = await revertChange('c1', REVERTER)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('DETACH DELETE'),
+      expect.objectContaining({ targetId: 'I001' })
+    )
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining("SET c.status = 'reverted'"),
+      expect.objectContaining({ id: 'c1' })
+    )
+    expect(mockRecord).toHaveBeenCalledWith(
+      'alice@example.com',
+      'Alice',
+      'DELETE_PERSON',
+      'I001',
+      expect.any(Object),
+      expect.any(Object)
+    )
+  })
+})

--- a/src/lib/revert.test.ts
+++ b/src/lib/revert.test.ts
@@ -275,3 +275,35 @@ describe('revertChange — UPDATE_PERSON', () => {
     expect(mockWrite).not.toHaveBeenCalled()
   })
 })
+
+describe('revertChange — edge cases', () => {
+  it('returns 404 when the change id does not match', async () => {
+    mockRead.mockResolvedValueOnce([])
+
+    const result = await revertChange('missing', REVERTER)
+
+    expect(result).toEqual({ ok: false, status: 404, error: 'Change not found' })
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 Change is not live when status !== live', async () => {
+    mockRead.mockResolvedValueOnce([
+      {
+        id: 'c9',
+        changeType: 'CREATE_PERSON',
+        targetId: 'I001',
+        previousValue: null,
+        newValue: '{}',
+        status: 'reverted',
+        authorEmail: 'a@b',
+        authorName: 'A',
+        appliedAt: '2026-01-01',
+      },
+    ])
+
+    const result = await revertChange('c9', REVERTER)
+
+    expect(result).toEqual({ ok: false, status: 409, error: 'Change is not live' })
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/revert.test.ts
+++ b/src/lib/revert.test.ts
@@ -54,4 +54,33 @@ describe('revertChange — CREATE_PERSON', () => {
       expect.any(Object)
     )
   })
+
+  it('returns 409 has-relationships when person has UNION or CHILD edges', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c1',
+          changeType: 'CREATE_PERSON',
+          targetId: 'I001',
+          previousValue: null,
+          newValue: '{}',
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([{ edges: 2 }])
+
+    const result = await revertChange('c1', REVERTER)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 409,
+        conflict: { kind: 'has-relationships', detail: expect.stringContaining('relationship') },
+      })
+    )
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/revert.test.ts
+++ b/src/lib/revert.test.ts
@@ -84,3 +84,119 @@ describe('revertChange — CREATE_PERSON', () => {
     expect(mockWrite).not.toHaveBeenCalled()
   })
 })
+
+describe('revertChange — ADD_RELATIONSHIP', () => {
+  it('spouse happy path: deletes union when unionEdges=2 and childEdges=0', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c2',
+          changeType: 'ADD_RELATIONSHIP',
+          targetId: 'I001',
+          previousValue: null,
+          newValue: JSON.stringify({ type: 'spouse', targetId: 'I002', unionId: 'U001' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([{ unionEdges: 2, childEdges: 0 }])
+
+    const result = await revertChange('c2', REVERTER)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('MATCH (u:Union {gedcomId: $unionId}) DETACH DELETE u'),
+      expect.objectContaining({ unionId: 'U001' })
+    )
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining("SET c.status = 'reverted'"),
+      expect.objectContaining({ id: 'c2' })
+    )
+  })
+
+  it('parent/child happy path: deletes union when unionEdges=1 and childEdges=1', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c3',
+          changeType: 'ADD_RELATIONSHIP',
+          targetId: 'I001',
+          previousValue: null,
+          newValue: JSON.stringify({ type: 'parent', targetId: 'I003', unionId: 'U002' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([{ unionEdges: 1, childEdges: 1 }])
+
+    const result = await revertChange('c3', REVERTER)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('MATCH (u:Union {gedcomId: $unionId}) DETACH DELETE u'),
+      expect.objectContaining({ unionId: 'U002' })
+    )
+  })
+
+  it('spouse block: returns 409 union-touched when union has a CHILD edge', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c4',
+          changeType: 'ADD_RELATIONSHIP',
+          targetId: 'I001',
+          previousValue: null,
+          newValue: JSON.stringify({ type: 'spouse', targetId: 'I002', unionId: 'U003' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([{ unionEdges: 2, childEdges: 1 }])
+
+    const result = await revertChange('c4', REVERTER)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 409,
+        conflict: expect.objectContaining({ kind: 'union-touched' }),
+      })
+    )
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+
+  it('parent/child block: returns 409 union-touched when union has extra UNION or CHILD', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c5',
+          changeType: 'ADD_RELATIONSHIP',
+          targetId: 'I001',
+          previousValue: null,
+          newValue: JSON.stringify({ type: 'child', targetId: 'I004', unionId: 'U004' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([{ unionEdges: 2, childEdges: 1 }])
+
+    const result = await revertChange('c5', REVERTER)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 409,
+        conflict: expect.objectContaining({ kind: 'union-touched' }),
+      })
+    )
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/revert.test.ts
+++ b/src/lib/revert.test.ts
@@ -200,3 +200,78 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
     expect(mockWrite).not.toHaveBeenCalled()
   })
 })
+
+describe('revertChange — UPDATE_PERSON', () => {
+  it('happy path: applies previousValue to Person, flips status=reverted', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c6',
+          changeType: 'UPDATE_PERSON',
+          targetId: 'I001',
+          previousValue: JSON.stringify({ name: 'Old', birthYear: 1900, bogusField: 'ignore' }),
+          newValue: JSON.stringify({ name: 'New', birthYear: 1901 }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      // later-change lookup returns nothing
+      .mockResolvedValueOnce([])
+
+    const result = await revertChange('c6', REVERTER)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('SET p += $prevValue'),
+      expect.objectContaining({
+        targetId: 'I001',
+        prevValue: expect.objectContaining({ name: 'Old', birthYear: 1900 }),
+      })
+    )
+    // The bogus field must be filtered out
+    const setCall = mockWrite.mock.calls.find(([cypher]) =>
+      typeof cypher === 'string' && cypher.includes('SET p += $prevValue')
+    )
+    expect(setCall).toBeDefined()
+    const prevValueArg = (setCall![1] as { prevValue: Record<string, unknown> }).prevValue
+    expect(prevValueArg).not.toHaveProperty('bogusField')
+
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining("SET c.status = 'reverted'"),
+      expect.objectContaining({ id: 'c6' })
+    )
+  })
+
+  it('block: returns 409 field-updated-later when a later UPDATE_PERSON touches an overlapping field', async () => {
+    mockRead
+      .mockResolvedValueOnce([
+        {
+          id: 'c7',
+          changeType: 'UPDATE_PERSON',
+          targetId: 'I001',
+          previousValue: JSON.stringify({ name: 'Old', birthYear: 1900 }),
+          newValue: JSON.stringify({ name: 'Mid' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'c8', newValue: JSON.stringify({ name: 'Newer' }) },
+      ])
+
+    const result = await revertChange('c7', REVERTER)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 409,
+        conflict: expect.objectContaining({ kind: 'field-updated-later' }),
+      })
+    )
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/revert.test.ts
+++ b/src/lib/revert.test.ts
@@ -19,6 +19,7 @@ beforeEach(() => {
 describe('revertChange — CREATE_PERSON', () => {
   it('deletes the Person, flips status=reverted, writes DELETE_PERSON audit', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c1',
@@ -32,6 +33,7 @@ describe('revertChange — CREATE_PERSON', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: edge count for CREATE_PERSON block check
       .mockResolvedValueOnce([{ edges: 0 }])
 
     const result = await revertChange('c1', REVERTER)
@@ -57,6 +59,7 @@ describe('revertChange — CREATE_PERSON', () => {
 
   it('returns 409 has-relationships when person has UNION or CHILD edges', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c1',
@@ -70,6 +73,7 @@ describe('revertChange — CREATE_PERSON', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: edge count for CREATE_PERSON block check
       .mockResolvedValueOnce([{ edges: 2 }])
 
     const result = await revertChange('c1', REVERTER)
@@ -88,6 +92,7 @@ describe('revertChange — CREATE_PERSON', () => {
 describe('revertChange — ADD_RELATIONSHIP', () => {
   it('spouse happy path: deletes union when unionEdges=2 and childEdges=0', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c2',
@@ -101,6 +106,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: union edge counts (spouse/child) for pristine check
       .mockResolvedValueOnce([{ unionEdges: 2, childEdges: 0 }])
 
     const result = await revertChange('c2', REVERTER)
@@ -118,6 +124,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
 
   it('parent/child happy path: deletes union when unionEdges=1 and childEdges=1', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c3',
@@ -131,6 +138,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: union edge counts (spouse/child) for pristine check
       .mockResolvedValueOnce([{ unionEdges: 1, childEdges: 1 }])
 
     const result = await revertChange('c3', REVERTER)
@@ -144,6 +152,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
 
   it('spouse block: returns 409 union-touched when union has a CHILD edge', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c4',
@@ -157,6 +166,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: union edge counts (spouse/child) for pristine check
       .mockResolvedValueOnce([{ unionEdges: 2, childEdges: 1 }])
 
     const result = await revertChange('c4', REVERTER)
@@ -173,6 +183,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
 
   it('parent/child block: returns 409 union-touched when union has extra UNION or CHILD', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c5',
@@ -186,6 +197,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: union edge counts (spouse/child) for pristine check
       .mockResolvedValueOnce([{ unionEdges: 2, childEdges: 1 }])
 
     const result = await revertChange('c5', REVERTER)
@@ -204,6 +216,7 @@ describe('revertChange — ADD_RELATIONSHIP', () => {
 describe('revertChange — UPDATE_PERSON', () => {
   it('happy path: applies previousValue to Person, flips status=reverted', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c6',
@@ -217,7 +230,7 @@ describe('revertChange — UPDATE_PERSON', () => {
           appliedAt: '2026-01-01',
         },
       ])
-      // later-change lookup returns nothing
+      // 2nd read: later-change lookup for field-updated-later conflict (empty = no later edits)
       .mockResolvedValueOnce([])
 
     const result = await revertChange('c6', REVERTER)
@@ -246,6 +259,7 @@ describe('revertChange — UPDATE_PERSON', () => {
 
   it('block: returns 409 field-updated-later when a later UPDATE_PERSON touches an overlapping field', async () => {
     mockRead
+      // 1st read: fetch change row
       .mockResolvedValueOnce([
         {
           id: 'c7',
@@ -259,6 +273,7 @@ describe('revertChange — UPDATE_PERSON', () => {
           appliedAt: '2026-01-01',
         },
       ])
+      // 2nd read: later-change lookup (one later UPDATE_PERSON touching 'name')
       .mockResolvedValueOnce([
         { id: 'c8', newValue: JSON.stringify({ name: 'Newer' }) },
       ])
@@ -274,10 +289,47 @@ describe('revertChange — UPDATE_PERSON', () => {
     )
     expect(mockWrite).not.toHaveBeenCalled()
   })
+
+  it('no false-positive block: later UPDATE_PERSON with only disallowed keys does not conflict', async () => {
+    mockRead
+      // 1st read: fetch change row
+      .mockResolvedValueOnce([
+        {
+          id: 'c10',
+          changeType: 'UPDATE_PERSON',
+          targetId: 'I001',
+          previousValue: JSON.stringify({ name: 'Old', birthYear: 1900 }),
+          newValue: JSON.stringify({ name: 'Mid' }),
+          status: 'live',
+          authorEmail: 'a@b',
+          authorName: 'A',
+          appliedAt: '2026-01-01',
+        },
+      ])
+      // 2nd read: later-change lookup returns a change whose newValue contains ONLY
+      // disallowed keys (not in ALLOWED_PATCH_FIELDS). The revert-keys set is filtered
+      // through ALLOWED_PATCH_FIELDS, so overlap must be empty and revert must succeed.
+      .mockResolvedValueOnce([
+        { id: 'c11', newValue: JSON.stringify({ bogusField: 'x', anotherJunk: 42 }) },
+      ])
+
+    const result = await revertChange('c10', REVERTER)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('SET p += $prevValue'),
+      expect.objectContaining({ targetId: 'I001' })
+    )
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining("SET c.status = 'reverted'"),
+      expect.objectContaining({ id: 'c10' })
+    )
+  })
 })
 
 describe('revertChange — edge cases', () => {
   it('returns 404 when the change id does not match', async () => {
+    // 1st read: fetch change row (empty = not found)
     mockRead.mockResolvedValueOnce([])
 
     const result = await revertChange('missing', REVERTER)
@@ -287,6 +339,7 @@ describe('revertChange — edge cases', () => {
   })
 
   it('returns 409 Change is not live when status !== live', async () => {
+    // 1st read: fetch change row (already reverted)
     mockRead.mockResolvedValueOnce([
       {
         id: 'c9',

--- a/src/lib/revert.ts
+++ b/src/lib/revert.ts
@@ -52,10 +52,19 @@ export async function revertChange(
   }
 
   if (change.changeType === 'ADD_RELATIONSHIP') {
-    const parsed = JSON.parse(change.newValue) as {
+    let parsed: {
       type: 'spouse' | 'parent' | 'child'
       targetId: string
       unionId: string
+    }
+    try {
+      parsed = JSON.parse(change.newValue) as {
+        type: 'spouse' | 'parent' | 'child'
+        targetId: string
+        unionId: string
+      }
+    } catch {
+      return { ok: false, status: 409, error: 'Malformed change record: cannot parse newValue' }
     }
     const edgeRows = await read<{ unionEdges: number; childEdges: number }>(
       `MATCH (u:Union {gedcomId: $unionId})
@@ -115,6 +124,15 @@ export async function revertChange(
       }
     }
 
+    // Parse BEFORE any mutation so malformed newValue can't leave the graph in
+    // a half-reverted state (person deleted, no audit written).
+    let prevFromCreate: Record<string, unknown>
+    try {
+      prevFromCreate = JSON.parse(change.newValue) as Record<string, unknown>
+    } catch {
+      return { ok: false, status: 409, error: 'Malformed change record: cannot parse newValue' }
+    }
+
     await write(
       `MATCH (p:Person {gedcomId: $targetId}) DETACH DELETE p`,
       { targetId: change.targetId }
@@ -124,15 +142,18 @@ export async function revertChange(
       { id: change.id }
     )
 
-    const prevFromCreate = JSON.parse(change.newValue) as Record<string, unknown>
-    await recordChange(
-      reverter.email,
-      reverter.name,
-      'DELETE_PERSON',
-      change.targetId,
-      prevFromCreate,
-      {}
-    )
+    try {
+      await recordChange(
+        reverter.email,
+        reverter.name,
+        'DELETE_PERSON',
+        change.targetId,
+        prevFromCreate,
+        {}
+      )
+    } catch (auditErr) {
+      console.error('Audit recordChange failed (non-fatal)', auditErr)
+    }
 
     return { ok: true }
   }

--- a/src/lib/revert.ts
+++ b/src/lib/revert.ts
@@ -29,8 +29,72 @@ export interface ChangeRow {
 }
 
 export async function revertChange(
-  _changeId: string,
-  _reverter: { email: string; name: string }
+  changeId: string,
+  reverter: { email: string; name: string }
 ): Promise<RevertOutcome> {
-  throw new Error('not implemented')
+  const rows = await read<ChangeRow>(
+    `MATCH (c:Change {id: $id})
+     RETURN c.id AS id, c.changeType AS changeType, c.targetId AS targetId,
+            c.previousValue AS previousValue, c.newValue AS newValue,
+            c.status AS status, c.authorEmail AS authorEmail,
+            c.authorName AS authorName, c.appliedAt AS appliedAt`,
+    { id: changeId }
+  )
+
+  if (rows.length === 0) {
+    return { ok: false, status: 404, error: 'Change not found' }
+  }
+
+  const change = rows[0]
+
+  if (change.status !== 'live') {
+    return { ok: false, status: 409, error: 'Change is not live' }
+  }
+
+  if (change.changeType === 'CREATE_PERSON') {
+    const edgeRows = await read<{ edges: number }>(
+      `MATCH (p:Person {gedcomId: $targetId})
+       OPTIONAL MATCH (p)-[r]-()
+       RETURN count(r) AS edges`,
+      { targetId: change.targetId }
+    )
+    const edgeCount = edgeRows[0]?.edges ?? 0
+    if (edgeCount > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'Cannot revert: person has relationships',
+        conflict: {
+          kind: 'has-relationships',
+          detail: `Person has ${edgeCount} relationship(s); remove them before reverting.`,
+        },
+      }
+    }
+
+    await write(
+      `MATCH (p:Person {gedcomId: $targetId}) DETACH DELETE p`,
+      { targetId: change.targetId }
+    )
+    await write(
+      `MATCH (c:Change {id: $id}) SET c.status = 'reverted'`,
+      { id: change.id }
+    )
+
+    const prevFromCreate = JSON.parse(change.newValue) as Record<string, unknown>
+    await recordChange(
+      reverter.email,
+      reverter.name,
+      'DELETE_PERSON',
+      change.targetId,
+      prevFromCreate,
+      {}
+    )
+
+    return { ok: true }
+  }
+
+  // Touch imports so TypeScript does not complain until later tasks use them.
+  void ALLOWED_PATCH_FIELDS
+
+  return { ok: false, status: 409, error: 'Unsupported change type' }
 }

--- a/src/lib/revert.ts
+++ b/src/lib/revert.ts
@@ -137,8 +137,57 @@ export async function revertChange(
     return { ok: true }
   }
 
-  // Touch imports so TypeScript does not complain until later tasks use them.
-  void ALLOWED_PATCH_FIELDS
+  if (change.changeType === 'UPDATE_PERSON') {
+    const rawPrev =
+      change.previousValue !== null
+        ? (JSON.parse(change.previousValue) as Record<string, unknown>)
+        : {}
+    const allowedKeys = new Set<string>(ALLOWED_PATCH_FIELDS)
+    const prevValue: Record<string, unknown> = {}
+    for (const key of Object.keys(rawPrev)) {
+      if (allowedKeys.has(key)) prevValue[key] = rawPrev[key]
+    }
+    const revertKeys = new Set(Object.keys(prevValue))
+
+    const laterRows = await read<{ id: string; newValue: string }>(
+      `MATCH (c:Change { status: 'live', changeType: 'UPDATE_PERSON', targetId: $targetId })
+       WHERE c.appliedAt > $appliedAt AND c.id <> $id
+       RETURN c.id AS id, c.newValue AS newValue`,
+      { targetId: change.targetId, appliedAt: change.appliedAt, id: change.id }
+    )
+
+    for (const row of laterRows) {
+      let laterNew: Record<string, unknown>
+      try {
+        laterNew = JSON.parse(row.newValue) as Record<string, unknown>
+      } catch {
+        continue
+      }
+      const overlap = Object.keys(laterNew).filter(k => revertKeys.has(k))
+      if (overlap.length > 0) {
+        return {
+          ok: false,
+          status: 409,
+          error: 'Cannot revert: a later edit changed the same field(s)',
+          conflict: {
+            kind: 'field-updated-later',
+            detail: `A later edit (${row.id}) modified field(s): ${overlap.join(', ')}.`,
+          },
+        }
+      }
+    }
+
+    await write(
+      `MATCH (p:Person {gedcomId: $targetId}) SET p += $prevValue`,
+      { targetId: change.targetId, prevValue }
+    )
+    await write(
+      `MATCH (c:Change {id: $id}) SET c.status = 'reverted'`,
+      { id: change.id }
+    )
+
+    return { ok: true }
+  }
 
   return { ok: false, status: 409, error: 'Unsupported change type' }
 }

--- a/src/lib/revert.ts
+++ b/src/lib/revert.ts
@@ -51,6 +51,50 @@ export async function revertChange(
     return { ok: false, status: 409, error: 'Change is not live' }
   }
 
+  if (change.changeType === 'ADD_RELATIONSHIP') {
+    const parsed = JSON.parse(change.newValue) as {
+      type: 'spouse' | 'parent' | 'child'
+      targetId: string
+      unionId: string
+    }
+    const edgeRows = await read<{ unionEdges: number; childEdges: number }>(
+      `MATCH (u:Union {gedcomId: $unionId})
+       OPTIONAL MATCH (u)<-[ue:UNION]-()
+       OPTIONAL MATCH (u)-[ce:CHILD]->()
+       RETURN count(DISTINCT ue) AS unionEdges, count(DISTINCT ce) AS childEdges`,
+      { unionId: parsed.unionId }
+    )
+    const { unionEdges = 0, childEdges = 0 } = edgeRows[0] ?? {}
+
+    const pristine =
+      parsed.type === 'spouse'
+        ? unionEdges === 2 && childEdges === 0
+        : unionEdges === 1 && childEdges === 1
+
+    if (!pristine) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'Cannot revert: union has been modified since',
+        conflict: {
+          kind: 'union-touched',
+          detail: `Union has ${unionEdges} spouse edge(s) and ${childEdges} child edge(s); other edits are present, so reverting this relationship alone would leave the union inconsistent.`,
+        },
+      }
+    }
+
+    await write(
+      `MATCH (u:Union {gedcomId: $unionId}) DETACH DELETE u`,
+      { unionId: parsed.unionId }
+    )
+    await write(
+      `MATCH (c:Change {id: $id}) SET c.status = 'reverted'`,
+      { id: change.id }
+    )
+
+    return { ok: true }
+  }
+
   if (change.changeType === 'CREATE_PERSON') {
     const edgeRows = await read<{ edges: number }>(
       `MATCH (p:Person {gedcomId: $targetId})

--- a/src/lib/revert.ts
+++ b/src/lib/revert.ts
@@ -1,0 +1,36 @@
+import { read, write } from '@/lib/neo4j'
+import { recordChange } from '@/lib/changes'
+import { ALLOWED_PATCH_FIELDS } from '@/lib/patches'
+
+export type ConflictKind =
+  | 'has-relationships'
+  | 'union-touched'
+  | 'field-updated-later'
+
+export interface RevertConflict {
+  kind: ConflictKind
+  detail: string
+}
+
+export type RevertOutcome =
+  | { ok: true }
+  | { ok: false; status: 404 | 409; error: string; conflict?: RevertConflict }
+
+export interface ChangeRow {
+  id: string
+  changeType: 'CREATE_PERSON' | 'ADD_RELATIONSHIP' | 'UPDATE_PERSON' | 'DELETE_PERSON'
+  targetId: string
+  previousValue: string | null
+  newValue: string
+  status: string
+  authorEmail: string
+  authorName: string
+  appliedAt: string
+}
+
+export async function revertChange(
+  _changeId: string,
+  _reverter: { email: string; name: string }
+): Promise<RevertOutcome> {
+  throw new Error('not implemented')
+}

--- a/tests/e2e/helpers/revert-mocks.ts
+++ b/tests/e2e/helpers/revert-mocks.ts
@@ -1,0 +1,48 @@
+import type { Page, Route } from '@playwright/test'
+
+/** Signed-in user surfaced by the mocked next-auth session endpoint. */
+export const signedInUser = {
+  name: 'E2E Test User',
+  email: 'e2e@example.com',
+  image: null,
+}
+
+/** Mocks `/api/auth/session` with a signed-in user, expiring in 2099. */
+export async function mockSignedInSession(page: Page) {
+  await page.route(/\/api\/auth\/session\b/, (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: signedInUser,
+        expires: '2099-01-01T00:00:00.000Z',
+      }),
+    })
+  )
+}
+
+/**
+ * Mocks `/api/persons` and `/api/tree/...` with the provided fixtures so the
+ * canvas can render without hitting Neo4j.
+ */
+export async function mockPersonsAndTree(
+  page: Page,
+  persons: unknown[],
+  treeResponse: unknown,
+) {
+  await page.route(/\/api\/persons/, (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(persons),
+    })
+  )
+
+  await page.route(/\/api\/tree\//, (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(treeResponse),
+    })
+  )
+}

--- a/tests/e2e/revert-delete-person.spec.ts
+++ b/tests/e2e/revert-delete-person.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockPersonsAndTree, mockSignedInSession } from './helpers/revert-mocks'
 
 /**
  * E2E tests for the PersonDrawer "Delete this person" button (Task 11).
@@ -16,12 +17,6 @@ import { test, expect } from '@playwright/test'
  */
 
 // ─── Shared fixtures ────────────────────────────────────────────────────────
-
-const signedInUser = {
-  name: 'E2E Test User',
-  email: 'e2e@example.com',
-  image: null,
-}
 
 const mockAlice = {
   gedcomId: '@IALICE@',
@@ -80,47 +75,19 @@ const myChangesEmpty = {
   updateChanges: [],
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
+const alicePersonsList = [
+  {
+    gedcomId: '@IALICE@',
+    name: 'Alice NewPerson',
+    sex: 'F',
+    birthYear: '1990',
+    deathYear: null,
+    birthPlace: null,
+  },
+]
 
-async function mockSignedInSession(page: import('@playwright/test').Page) {
-  await page.route(/\/api\/auth\/session\b/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        user: signedInUser,
-        expires: '2099-01-01T00:00:00.000Z',
-      }),
-    })
-  )
-}
-
-async function mockPersonsAndTree(page: import('@playwright/test').Page) {
-  await page.route(/\/api\/persons/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([
-        {
-          gedcomId: '@IALICE@',
-          name: 'Alice NewPerson',
-          sex: 'F',
-          birthYear: '1990',
-          deathYear: null,
-          birthPlace: null,
-        },
-      ]),
-    })
-  )
-
-  await page.route(/\/api\/tree\//, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(aliceTreeResponse),
-    })
-  )
-}
+const mockAliceCanvas = (page: import('@playwright/test').Page) =>
+  mockPersonsAndTree(page, alicePersonsList, aliceTreeResponse)
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -129,7 +96,7 @@ test.describe('Revert: delete-person button', () => {
     let revertPostCount = 0
 
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockAliceCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({
@@ -184,7 +151,7 @@ test.describe('Revert: delete-person button', () => {
 
   test('button visible but disabled with tooltip when person has relationships', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockAliceCanvas(page)
 
     const aliceWithParent = {
       ...mockAlice,
@@ -234,7 +201,7 @@ test.describe('Revert: delete-person button', () => {
 
   test('button absent when createChange is null', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockAliceCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({
@@ -268,7 +235,7 @@ test.describe('Revert: delete-person button', () => {
 
   test('409 from revert endpoint surfaces conflictingChange.detail inline in the drawer', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockAliceCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({

--- a/tests/e2e/revert-delete-person.spec.ts
+++ b/tests/e2e/revert-delete-person.spec.ts
@@ -1,0 +1,321 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for the PersonDrawer "Delete this person" button (Task 11).
+ *
+ * Verifies the four scenarios from the plan:
+ *   1. Button visible + enabled when my-changes returns a createChange AND
+ *      person detail has no parents/siblings/marriages. Click → confirm →
+ *      drawer closes and one POST is observed to /api/changes/<id>/revert.
+ *   2. Button visible but disabled (with title tooltip) when person detail has
+ *      relationships.
+ *   3. Button absent entirely when createChange is null.
+ *   4. 409 from the revert endpoint surfaces conflictingChange.detail inline.
+ *
+ * All routes are mocked; the suite runs entirely against the local dev server.
+ */
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+const signedInUser = {
+  name: 'E2E Test User',
+  email: 'e2e@example.com',
+  image: null,
+}
+
+const mockAlice = {
+  gedcomId: '@IALICE@',
+  name: 'Alice NewPerson',
+  sex: 'F',
+  birthYear: '1990',
+  deathYear: null,
+  birthPlace: null,
+  deathPlace: null,
+  occupation: null,
+  notes: null,
+  parents: [],
+  siblings: [],
+  marriages: [],
+}
+
+const aliceTreeResponse = {
+  nodes: [
+    {
+      id: 'node-@IALICE@',
+      type: 'person',
+      data: {
+        gedcomId: '@IALICE@',
+        name: 'Alice NewPerson',
+        sex: 'F',
+        birthYear: '1990',
+        deathYear: null,
+        birthPlace: null,
+        deathPlace: null,
+        occupation: null,
+        notes: null,
+        isRoot: true,
+        generation: 0,
+      },
+      position: { x: 0, y: 0 },
+    },
+  ],
+  edges: [],
+}
+
+const myChangesWithCreate = {
+  createChange: {
+    id: 'change-create-1',
+    changeType: 'CREATE_PERSON',
+    targetId: '@IALICE@',
+    newValue: { name: 'Alice NewPerson' },
+    appliedAt: '2026-04-23T10:00:00.000Z',
+  },
+  relationshipChanges: [],
+  updateChanges: [],
+}
+
+const myChangesEmpty = {
+  createChange: null,
+  relationshipChanges: [],
+  updateChanges: [],
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function mockSignedInSession(page: import('@playwright/test').Page) {
+  await page.route(/\/api\/auth\/session\b/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: signedInUser,
+        expires: '2099-01-01T00:00:00.000Z',
+      }),
+    })
+  )
+}
+
+async function mockPersonsAndTree(page: import('@playwright/test').Page) {
+  await page.route(/\/api\/persons/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          gedcomId: '@IALICE@',
+          name: 'Alice NewPerson',
+          sex: 'F',
+          birthYear: '1990',
+          deathYear: null,
+          birthPlace: null,
+        },
+      ]),
+    })
+  )
+
+  await page.route(/\/api\/tree\//, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(aliceTreeResponse),
+    })
+  )
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe('Revert: delete-person button', () => {
+  test('button visible + enabled when createChange exists and no relationships; click reverts and closes drawer', async ({ page }) => {
+    let revertPostCount = 0
+
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesWithCreate),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockAlice),
+      })
+    )
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, async (route) => {
+      if (route.request().method() === 'POST') {
+        revertPostCount += 1
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Alice', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    const drawer = page.getByTestId('person-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(page.getByTestId('person-drawer-marriages')).toBeVisible({ timeout: 5_000 })
+
+    const deleteBtn = page.getByTestId('person-drawer-delete')
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 })
+    await expect(deleteBtn).toBeEnabled()
+
+    page.once('dialog', d => d.accept())
+    await deleteBtn.click()
+
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 })
+    expect(revertPostCount).toBe(1)
+  })
+
+  test('button visible but disabled with tooltip when person has relationships', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    const aliceWithParent = {
+      ...mockAlice,
+      parents: [
+        {
+          gedcomId: '@IBOB@',
+          name: 'Bob Parent',
+          sex: 'M',
+          birthYear: '1960',
+          deathYear: null,
+        },
+      ],
+    }
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesWithCreate),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(aliceWithParent),
+      })
+    )
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Alice', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    const drawer = page.getByTestId('person-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(page.getByTestId('person-drawer-parents')).toContainText('Bob Parent', { timeout: 5_000 })
+
+    const deleteBtn = page.getByTestId('person-drawer-delete')
+    await expect(deleteBtn).toBeVisible()
+    await expect(deleteBtn).toBeDisabled()
+    await expect(deleteBtn).toHaveAttribute('title', /relationships/i)
+  })
+
+  test('button absent when createChange is null', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesEmpty),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockAlice),
+      })
+    )
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Alice', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    const drawer = page.getByTestId('person-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(page.getByTestId('person-drawer-marriages')).toBeVisible({ timeout: 5_000 })
+
+    await expect(page.getByTestId('person-drawer-delete')).toHaveCount(0)
+  })
+
+  test('409 from revert endpoint surfaces conflictingChange.detail inline in the drawer', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesWithCreate),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockAlice),
+      })
+    )
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Has relationships',
+          conflictingChange: {
+            kind: 'has-relationships',
+            detail: 'Cannot delete — person has 2 relationships',
+          },
+        }),
+      })
+    )
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Alice', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    const drawer = page.getByTestId('person-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(page.getByTestId('person-drawer-marriages')).toBeVisible({ timeout: 5_000 })
+
+    page.once('dialog', d => d.accept())
+    await page.getByTestId('person-drawer-delete').click()
+
+    await expect(drawer).toBeVisible()
+    await expect(page.getByTestId('person-drawer-action-error'))
+      .toContainText('Cannot delete — person has 2 relationships', { timeout: 5_000 })
+  })
+})

--- a/tests/e2e/revert-edit-list.spec.ts
+++ b/tests/e2e/revert-edit-list.spec.ts
@@ -1,0 +1,304 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for the PersonDrawer "Your edits to this person" list in edit mode
+ * (Task 13).
+ *
+ * Verifies:
+ *   1. Section hidden when no updateChanges; shown with one row per change
+ *      (keys + ISO timestamp + Revert button) otherwise.
+ *   2. Revert → confirm → row disappears after refetch; POST observed.
+ *   3. 409 surfaces conflictingChange.detail inline in the drawer.
+ */
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+const signedInUser = {
+  name: 'E2E Test User',
+  email: 'e2e@example.com',
+  image: null,
+}
+
+const mockDonald = {
+  gedcomId: '@IDONALD@',
+  name: 'Donald Grocott',
+  sex: 'M',
+  birthYear: '1920',
+  deathYear: null,
+  birthPlace: 'Melbourne, Victoria',
+  deathPlace: null,
+  occupation: null,
+  notes: null,
+  parents: [],
+  siblings: [],
+  marriages: [],
+}
+
+const donaldTreeResponse = {
+  nodes: [
+    {
+      id: 'node-@IDONALD@',
+      type: 'person',
+      data: {
+        gedcomId: '@IDONALD@',
+        name: 'Donald Grocott',
+        sex: 'M',
+        birthYear: '1920',
+        deathYear: null,
+        birthPlace: 'Melbourne, Victoria',
+        deathPlace: null,
+        occupation: null,
+        notes: null,
+        isRoot: true,
+        generation: 0,
+      },
+      position: { x: 0, y: 0 },
+    },
+  ],
+  edges: [],
+}
+
+const myChangesNoEdits = {
+  createChange: null,
+  relationshipChanges: [],
+  updateChanges: [],
+}
+
+const myChangesTwoEdits = {
+  createChange: null,
+  relationshipChanges: [],
+  updateChanges: [
+    {
+      id: 'change-upd-1',
+      newValue: { birthPlace: 'Melbourne, Victoria', occupation: 'Farmer' },
+      appliedAt: '2026-04-23T10:00:00.000Z',
+    },
+    {
+      id: 'change-upd-2',
+      newValue: { notes: 'Updated notes' },
+      appliedAt: '2026-04-20T12:00:00.000Z',
+    },
+  ],
+}
+
+const myChangesOneEditAfterRevert = {
+  createChange: null,
+  relationshipChanges: [],
+  updateChanges: [
+    {
+      id: 'change-upd-2',
+      newValue: { notes: 'Updated notes' },
+      appliedAt: '2026-04-20T12:00:00.000Z',
+    },
+  ],
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function mockSignedInSession(page: import('@playwright/test').Page) {
+  await page.route(/\/api\/auth\/session\b/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: signedInUser,
+        expires: '2099-01-01T00:00:00.000Z',
+      }),
+    })
+  )
+}
+
+async function mockPersonsAndTree(page: import('@playwright/test').Page) {
+  await page.route(/\/api\/persons/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { gedcomId: '@IDONALD@', name: 'Donald Grocott', sex: 'M', birthYear: '1920', deathYear: null, birthPlace: 'Melbourne, Victoria' },
+      ]),
+    })
+  )
+
+  await page.route(/\/api\/tree\//, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(donaldTreeResponse),
+    })
+  )
+}
+
+async function openEditMode(page: import('@playwright/test').Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByTestId('toolbar-viewing')).toContainText('Donald', { timeout: 15_000 })
+
+  const personNode = page.locator('.react-flow__node-person').first()
+  await expect(personNode).toBeVisible({ timeout: 10_000 })
+  await personNode.click()
+
+  await expect(page.getByTestId('person-drawer')).toBeVisible()
+  await page.getByTestId('person-drawer-edit').click()
+  await expect(page.getByTestId('person-drawer-edit-form')).toBeVisible()
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe('Revert: "Your edits" list in edit mode', () => {
+  test('section hidden when no updateChanges', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesNoEdits),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockDonald),
+      })
+    )
+
+    await openEditMode(page)
+    await expect(page.getByTestId('person-drawer-your-edits')).toHaveCount(0)
+  })
+
+  test('section shown with row per updateChange: keys + ISO timestamp + Revert button', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesTwoEdits),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockDonald),
+      })
+    )
+
+    await openEditMode(page)
+
+    const section = page.getByTestId('person-drawer-your-edits')
+    await expect(section).toBeVisible({ timeout: 5_000 })
+
+    const rows = section.locator('li[data-testid^="your-edit-"]')
+    await expect(rows).toHaveCount(2)
+
+    const row1 = page.getByTestId('your-edit-change-upd-1')
+    await expect(row1).toContainText('birthPlace')
+    await expect(row1).toContainText('occupation')
+    await expect(row1).toContainText('2026-04-23T10:00:00.000Z')
+    await expect(row1.getByRole('button', { name: /revert/i })).toBeVisible()
+
+    const row2 = page.getByTestId('your-edit-change-upd-2')
+    await expect(row2).toContainText('notes')
+    await expect(row2).toContainText('2026-04-20T12:00:00.000Z')
+  })
+
+  test('revert click → confirm → row disappears; POST observed', async ({ page }) => {
+    let revertPostCount = 0
+
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          revertPostCount === 0 ? myChangesTwoEdits : myChangesOneEditAfterRevert
+        ),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockDonald),
+      })
+    )
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, (route) => {
+      if (route.request().method() === 'POST') {
+        revertPostCount += 1
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        })
+        return
+      }
+      route.continue()
+    })
+
+    await openEditMode(page)
+
+    const row1 = page.getByTestId('your-edit-change-upd-1')
+    await expect(row1).toBeVisible({ timeout: 5_000 })
+
+    page.once('dialog', d => d.accept())
+    await page.getByTestId('your-edit-revert-change-upd-1').click()
+
+    await expect(page.getByTestId('your-edit-change-upd-1')).toHaveCount(0, { timeout: 5_000 })
+    await expect(page.getByTestId('your-edit-change-upd-2')).toBeVisible()
+
+    expect(revertPostCount).toBe(1)
+  })
+
+  test('409 surfaces conflictingChange.detail inline', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesTwoEdits),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockDonald),
+      })
+    )
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Field updated later',
+          conflictingChange: {
+            kind: 'field-updated-later',
+            detail: 'birthPlace was updated by a later change',
+          },
+        }),
+      })
+    )
+
+    await openEditMode(page)
+
+    page.once('dialog', d => d.accept())
+    await page.getByTestId('your-edit-revert-change-upd-1').click()
+
+    // The edit form stays visible; actionError renders below the inputs.
+    await expect(page.getByTestId('person-drawer-edit-form'))
+      .toContainText('birthPlace was updated by a later change', { timeout: 5_000 })
+  })
+})

--- a/tests/e2e/revert-edit-list.spec.ts
+++ b/tests/e2e/revert-edit-list.spec.ts
@@ -298,7 +298,7 @@ test.describe('Revert: "Your edits" list in edit mode', () => {
     await page.getByTestId('your-edit-revert-change-upd-1').click()
 
     // The edit form stays visible; actionError renders below the inputs.
-    await expect(page.getByTestId('person-drawer-edit-form'))
+    await expect(page.getByTestId('person-drawer-edit-action-error'))
       .toContainText('birthPlace was updated by a later change', { timeout: 5_000 })
   })
 })

--- a/tests/e2e/revert-edit-list.spec.ts
+++ b/tests/e2e/revert-edit-list.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockPersonsAndTree, mockSignedInSession } from './helpers/revert-mocks'
 
 /**
  * E2E tests for the PersonDrawer "Your edits to this person" list in edit mode
@@ -12,12 +13,6 @@ import { test, expect } from '@playwright/test'
  */
 
 // ─── Shared fixtures ────────────────────────────────────────────────────────
-
-const signedInUser = {
-  name: 'E2E Test User',
-  email: 'e2e@example.com',
-  image: null,
-}
 
 const mockDonald = {
   gedcomId: '@IDONALD@',
@@ -93,40 +88,12 @@ const myChangesOneEditAfterRevert = {
   ],
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
+const donaldPersonsList = [
+  { gedcomId: '@IDONALD@', name: 'Donald Grocott', sex: 'M', birthYear: '1920', deathYear: null, birthPlace: 'Melbourne, Victoria' },
+]
 
-async function mockSignedInSession(page: import('@playwright/test').Page) {
-  await page.route(/\/api\/auth\/session\b/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        user: signedInUser,
-        expires: '2099-01-01T00:00:00.000Z',
-      }),
-    })
-  )
-}
-
-async function mockPersonsAndTree(page: import('@playwright/test').Page) {
-  await page.route(/\/api\/persons/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([
-        { gedcomId: '@IDONALD@', name: 'Donald Grocott', sex: 'M', birthYear: '1920', deathYear: null, birthPlace: 'Melbourne, Victoria' },
-      ]),
-    })
-  )
-
-  await page.route(/\/api\/tree\//, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(donaldTreeResponse),
-    })
-  )
-}
+const mockDonaldCanvas = (page: import('@playwright/test').Page) =>
+  mockPersonsAndTree(page, donaldPersonsList, donaldTreeResponse)
 
 async function openEditMode(page: import('@playwright/test').Page) {
   await page.goto('/', { waitUntil: 'domcontentloaded' })
@@ -146,7 +113,7 @@ async function openEditMode(page: import('@playwright/test').Page) {
 test.describe('Revert: "Your edits" list in edit mode', () => {
   test('section hidden when no updateChanges', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({
@@ -170,7 +137,7 @@ test.describe('Revert: "Your edits" list in edit mode', () => {
 
   test('section shown with row per updateChange: keys + ISO timestamp + Revert button', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({
@@ -211,7 +178,7 @@ test.describe('Revert: "Your edits" list in edit mode', () => {
     let revertPostCount = 0
 
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({
@@ -260,7 +227,7 @@ test.describe('Revert: "Your edits" list in edit mode', () => {
 
   test('409 surfaces conflictingChange.detail inline', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({

--- a/tests/e2e/revert-remove-marriage.spec.ts
+++ b/tests/e2e/revert-remove-marriage.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for the PersonDrawer per-marriage × remove button (Task 12).
+ *
+ * Verifies the three scenarios from the plan:
+ *   1. × visible only on marriages whose unionId appears in
+ *      myChanges.relationshipChanges.
+ *   2. Click × → confirm → marriage disappears from the list; POST observed
+ *      to /api/changes/<id>/revert.
+ *   3. Mocked 409 surfaces conflictingChange.detail inline.
+ */
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+const signedInUser = {
+  name: 'E2E Test User',
+  email: 'e2e@example.com',
+  image: null,
+}
+
+const mockDonald = {
+  gedcomId: '@IDONALD@',
+  name: 'Donald Grocott',
+  sex: 'M',
+  birthYear: '1920',
+  deathYear: null,
+  birthPlace: null,
+  deathPlace: null,
+  occupation: null,
+  notes: null,
+  parents: [],
+  siblings: [],
+  marriages: [],
+}
+
+const mockSpouseA = {
+  gedcomId: '@ISPOUSE_A@',
+  name: 'Jane SpouseA',
+  sex: 'F',
+  birthYear: '1923',
+  deathYear: null,
+}
+
+const mockSpouseB = {
+  gedcomId: '@ISPOUSE_B@',
+  name: 'Mary SpouseB',
+  sex: 'F',
+  birthYear: '1930',
+  deathYear: null,
+}
+
+const donaldTreeResponse = {
+  nodes: [
+    {
+      id: 'node-@IDONALD@',
+      type: 'person',
+      data: {
+        gedcomId: '@IDONALD@',
+        name: 'Donald Grocott',
+        sex: 'M',
+        birthYear: '1920',
+        deathYear: null,
+        birthPlace: null,
+        deathPlace: null,
+        occupation: null,
+        notes: null,
+        isRoot: true,
+        generation: 0,
+      },
+      position: { x: 0, y: 0 },
+    },
+  ],
+  edges: [],
+}
+
+const donaldDetailTwoMarriages = {
+  ...mockDonald,
+  marriages: [
+    { unionId: '@FUNION_A@', marriageYear: null, marriagePlace: null, spouse: mockSpouseA, children: [] },
+    { unionId: '@FUNION_B@', marriageYear: null, marriagePlace: null, spouse: mockSpouseB, children: [] },
+  ],
+}
+
+const donaldDetailOneMarriage = {
+  ...mockDonald,
+  marriages: [
+    { unionId: '@FUNION_B@', marriageYear: null, marriagePlace: null, spouse: mockSpouseB, children: [] },
+  ],
+}
+
+// Only FUNION_A appears in relationshipChanges — FUNION_B was added by someone else.
+const myChangesOneRelationship = {
+  createChange: null,
+  relationshipChanges: [
+    {
+      id: 'change-rel-A',
+      newValue: { unionId: '@FUNION_A@', type: 'spouse' },
+      appliedAt: '2026-04-23T10:00:00.000Z',
+    },
+  ],
+  updateChanges: [],
+}
+
+const myChangesEmptyAfterRevert = {
+  createChange: null,
+  relationshipChanges: [],
+  updateChanges: [],
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function mockSignedInSession(page: import('@playwright/test').Page) {
+  await page.route(/\/api\/auth\/session\b/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: signedInUser,
+        expires: '2099-01-01T00:00:00.000Z',
+      }),
+    })
+  )
+}
+
+async function mockPersonsAndTree(page: import('@playwright/test').Page) {
+  await page.route(/\/api\/persons/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { gedcomId: '@IDONALD@', name: 'Donald Grocott', sex: 'M', birthYear: '1920', deathYear: null, birthPlace: null },
+      ]),
+    })
+  )
+
+  await page.route(/\/api\/tree\//, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(donaldTreeResponse),
+    })
+  )
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe('Revert: per-marriage remove (×) button', () => {
+  test('× visible only on marriages whose unionId appears in relationshipChanges', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesOneRelationship),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(donaldDetailTwoMarriages),
+      })
+    )
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Donald', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    await expect(page.getByTestId('person-drawer')).toBeVisible()
+    await expect(page.getByTestId('person-drawer-marriages')).toContainText('Jane SpouseA', { timeout: 5_000 })
+    await expect(page.getByTestId('person-drawer-marriages')).toContainText('Mary SpouseB')
+
+    await expect(page.getByTestId('marriage-remove-@FUNION_A@')).toBeVisible()
+    await expect(page.getByTestId('marriage-remove-@FUNION_B@')).toHaveCount(0)
+  })
+
+  test('click × → confirm → marriage disappears; POST observed', async ({ page }) => {
+    let revertPostCount = 0
+    let detailCallCount = 0
+    let myChangesCallCount = 0
+
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) => {
+      myChangesCallCount += 1
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          revertPostCount === 0 ? myChangesOneRelationship : myChangesEmptyAfterRevert
+        ),
+      })
+    })
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) => {
+      detailCallCount += 1
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          revertPostCount === 0 ? donaldDetailTwoMarriages : donaldDetailOneMarriage
+        ),
+      })
+    })
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, (route) => {
+      if (route.request().method() === 'POST') {
+        revertPostCount += 1
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        })
+        return
+      }
+      route.continue()
+    })
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Donald', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    await expect(page.getByTestId('person-drawer-marriages')).toContainText('Jane SpouseA', { timeout: 5_000 })
+
+    page.once('dialog', d => d.accept())
+    await page.getByTestId('marriage-remove-@FUNION_A@').click()
+
+    // After the revert, the drawer refetches — Jane's marriage disappears,
+    // Mary remains, and the × is no longer present.
+    await expect(page.getByTestId('person-drawer-marriages')).not.toContainText('Jane SpouseA', { timeout: 5_000 })
+    await expect(page.getByTestId('person-drawer-marriages')).toContainText('Mary SpouseB')
+
+    expect(revertPostCount).toBe(1)
+    // Ensure the drawer triggered a re-fetch after success.
+    expect(detailCallCount).toBeGreaterThan(1)
+    expect(myChangesCallCount).toBeGreaterThan(1)
+  })
+
+  test('mocked 409 surfaces conflictingChange.detail inline', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page)
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(myChangesOneRelationship),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(donaldDetailTwoMarriages),
+      })
+    )
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Union touched',
+          conflictingChange: {
+            kind: 'union-touched',
+            detail: 'Union has a CHILD edge — cannot remove',
+          },
+        }),
+      })
+    )
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Donald', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    await expect(page.getByTestId('person-drawer-marriages')).toContainText('Jane SpouseA', { timeout: 5_000 })
+
+    page.once('dialog', d => d.accept())
+    await page.getByTestId('marriage-remove-@FUNION_A@').click()
+
+    await expect(page.getByTestId('person-drawer-action-error'))
+      .toContainText('Union has a CHILD edge — cannot remove', { timeout: 5_000 })
+  })
+})

--- a/tests/e2e/revert-remove-marriage.spec.ts
+++ b/tests/e2e/revert-remove-marriage.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockPersonsAndTree, mockSignedInSession } from './helpers/revert-mocks'
 
 /**
  * E2E tests for the PersonDrawer per-marriage × remove button (Task 12).
@@ -12,12 +13,6 @@ import { test, expect } from '@playwright/test'
  */
 
 // ─── Shared fixtures ────────────────────────────────────────────────────────
-
-const signedInUser = {
-  name: 'E2E Test User',
-  email: 'e2e@example.com',
-  image: null,
-}
 
 const mockDonald = {
   gedcomId: '@IDONALD@',
@@ -108,47 +103,19 @@ const myChangesEmptyAfterRevert = {
   updateChanges: [],
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
+const donaldPersonsList = [
+  { gedcomId: '@IDONALD@', name: 'Donald Grocott', sex: 'M', birthYear: '1920', deathYear: null, birthPlace: null },
+]
 
-async function mockSignedInSession(page: import('@playwright/test').Page) {
-  await page.route(/\/api\/auth\/session\b/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        user: signedInUser,
-        expires: '2099-01-01T00:00:00.000Z',
-      }),
-    })
-  )
-}
-
-async function mockPersonsAndTree(page: import('@playwright/test').Page) {
-  await page.route(/\/api\/persons/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([
-        { gedcomId: '@IDONALD@', name: 'Donald Grocott', sex: 'M', birthYear: '1920', deathYear: null, birthPlace: null },
-      ]),
-    })
-  )
-
-  await page.route(/\/api\/tree\//, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(donaldTreeResponse),
-    })
-  )
-}
+const mockDonaldCanvas = (page: import('@playwright/test').Page) =>
+  mockPersonsAndTree(page, donaldPersonsList, donaldTreeResponse)
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 test.describe('Revert: per-marriage remove (×) button', () => {
   test('× visible only on marriages whose unionId appears in relationshipChanges', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({
@@ -187,7 +154,7 @@ test.describe('Revert: per-marriage remove (×) button', () => {
     let myChangesCallCount = 0
 
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) => {
       myChangesCallCount += 1
@@ -249,7 +216,7 @@ test.describe('Revert: per-marriage remove (×) button', () => {
 
   test('mocked 409 surfaces conflictingChange.detail inline', async ({ page }) => {
     await mockSignedInSession(page)
-    await mockPersonsAndTree(page)
+    await mockDonaldCanvas(page)
 
     await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
       route.fulfill({


### PR DESCRIPTION
## Summary
- Authors can now undo their own `CREATE_PERSON`, `ADD_RELATIONSHIP`, and `UPDATE_PERSON` changes directly from the PersonDrawer.
- Three new drawer surfaces: **Delete this person** button, per-marriage **×** remove, and **Your edits** revert list in edit mode.
- New `POST /api/changes/[id]/revert` endpoint, shared between authors and admins.
- New `GET /api/person/[id]/my-changes` endpoint surfaces the viewer's live changes for this person.
- Shared revert logic extracted to `src/lib/revert.ts`; the admin endpoint (`/api/admin/changes/[id]`) is refactored to delegate to it.
- Fixes the pre-existing admin bug where reverting a `CREATE_PERSON` or `ADD_RELATIONSHIP` silently flipped `status='reverted'` without undoing the graph mutation.

## Scope & blocking rules
- `CREATE_PERSON` revert blocks with 409 if the Person has any `UNION`/`CHILD` edges.
- `ADD_RELATIONSHIP` revert blocks with 409 if the Union has edges beyond the original shape (e.g. a child added later).
- `UPDATE_PERSON` revert blocks with 409 if a later `UPDATE_PERSON` touches any overlapping `ALLOWED_PATCH_FIELDS` key.
- Authorization: the change author OR any admin (`ADMIN_EMAILS`) can revert.

## Test plan
- [x] Unit (`src/lib/revert.test.ts`, 11 tests): happy + block paths for all three change types, not-found, already-reverted, disallowed-field filter.
- [x] API (`src/app/api/changes/[id]/revert/route.test.ts`, 8 tests): 401 / 403 / 404 / 409 / 200-author / 200-admin / conflictingChange shape.
- [x] API (`src/app/api/person/[id]/my-changes/route.test.ts`, 9 tests): auth, empty, split-by-type, unionId filter, ordering, malformed-JSON fallback.
- [x] Refactored admin endpoint (`src/app/api/admin/changes/[id]/route.test.ts`): 14 tests, including new delegation + 409 surfacing.
- [x] E2E (`tests/e2e/revert-delete-person.spec.ts`, `revert-remove-marriage.spec.ts`, `revert-edit-list.spec.ts`): 11 scenarios covering visibility, confirmation, successful revert, 409 conflict surfacing.
- [x] No regressions in `tests/e2e/add-spouse.spec.ts` or existing jest suites.
- [ ] Manual smoke on Vercel preview (the 3 pre-existing `admin-review.spec.ts` failures on `main` are unrelated).

## Design / plan
- `docs/plans/2026-04-23-revert-my-changes-design.md`
- `docs/plans/2026-04-23-revert-my-changes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)