### PR TITLE
fix(issue-127): fix cascade-revert 500 error when deleting person with connections

### DIFF
--- a/src/app/api/person/[id]/cascade-revert/route.test.ts
+++ b/src/app/api/person/[id]/cascade-revert/route.test.ts
@@ -68,16 +68,25 @@ describe('POST /api/person/[id]/cascade-revert', () => {
     mockCascade.mockResolvedValue({
       ok: false,
       status: 403,
-      error: 'blocked',
+      error: 'Blocked by foreign connection',
       blockedBy: [{ unionId: 'U001', authorEmail: 'bob@example.com', authorName: 'Bob' }],
     })
 
     const res = await POST(makeRequest(), makeParams('I001'))
     expect(res.status).toBe(403)
     const body = await res.json()
-    expect(body.error).toBe('blocked')
+    expect(body.error).toBe('Blocked by foreign connection')
     expect(body.blockedBy).toHaveLength(1)
     expect(body.blockedBy[0]).toMatchObject({ authorEmail: 'bob@example.com' })
+  })
+
+  it('returns 500 with "Database error" when cascadeRevertPerson returns a database error outcome', async () => {
+    mockAuth.mockResolvedValue(USER_SESSION as never)
+    mockCascade.mockResolvedValue({ ok: false, status: 500, error: 'Database error' })
+
+    const res = await POST(makeRequest(), makeParams('I001'))
+    expect(res.status).toBe(500)
+    expect(await res.json()).toMatchObject({ error: 'Database error' })
   })
 
   it('returns 500 when cascadeRevertPerson throws', async () => {

--- a/src/app/api/person/[id]/cascade-revert/route.ts
+++ b/src/app/api/person/[id]/cascade-revert/route.ts
@@ -28,7 +28,8 @@ export async function POST(
       { error: result.error, blockedBy: result.blockedBy },
       { status: result.status }
     )
-  } catch {
+  } catch (err) {
+    console.error('[cascade-revert] unhandled error for person', id, err)
     return NextResponse.json({ error: 'Failed to revert person' }, { status: 500 })
   }
 }

--- a/src/lib/cascade-revert.test.ts
+++ b/src/lib/cascade-revert.test.ts
@@ -19,10 +19,25 @@ const CREATE_ROW = {
   newValue: JSON.stringify({ name: 'Alice' }),
 }
 
+const PERSON_EXISTS = [{ exists: true }]
+
 beforeEach(() => {
   jest.clearAllMocks()
   mockWriteTransaction.mockResolvedValue(undefined as never)
   mockRecord.mockResolvedValue(undefined as never)
+})
+
+describe('cascadeRevertPerson — person not found', () => {
+  it('returns 404 with "Person not found" when the person node does not exist', async () => {
+    mockRead
+      .mockResolvedValueOnce([]) // createRows
+      .mockResolvedValueOnce([]) // unionRows
+      .mockResolvedValueOnce([]) // personRows — not found
+
+    const result = await cascadeRevertPerson('I001', AUTHOR)
+    expect(result).toEqual({ ok: false, status: 404, error: 'Person not found' })
+    expect(mockWriteTransaction).not.toHaveBeenCalled()
+  })
 })
 
 describe('cascadeRevertPerson — not found', () => {
@@ -30,6 +45,7 @@ describe('cascadeRevertPerson — not found', () => {
     mockRead
       .mockResolvedValueOnce([]) // createRows — none found
       .mockResolvedValueOnce([]) // unionRows
+      .mockResolvedValueOnce(PERSON_EXISTS) // person exists
 
     const result = await cascadeRevertPerson('I001', AUTHOR)
     expect(result).toEqual({ ok: false, status: 404, error: expect.any(String) })
@@ -42,6 +58,7 @@ describe('cascadeRevertPerson — no unions', () => {
     mockRead
       .mockResolvedValueOnce([CREATE_ROW])
       .mockResolvedValueOnce([]) // no unions
+      .mockResolvedValueOnce(PERSON_EXISTS)
 
     const result = await cascadeRevertPerson('I001', AUTHOR)
     expect(result).toEqual({ ok: true, unionsReverted: 0 })
@@ -63,16 +80,17 @@ describe('cascadeRevertPerson — no unions', () => {
 })
 
 describe('cascadeRevertPerson — with unions', () => {
-  it('returns 403 blocked when non-admin has a union authored by another user', async () => {
+  it('returns 403 with "Blocked by foreign connection" when non-admin has a union authored by another user', async () => {
     mockRead
       .mockResolvedValueOnce([CREATE_ROW])
       .mockResolvedValueOnce([{ unionId: 'U001' }])
+      .mockResolvedValueOnce(PERSON_EXISTS)
       .mockResolvedValueOnce([
         { id: 'rel1', authorEmail: 'bob@example.com', authorName: 'Bob', newValue: JSON.stringify({ unionId: 'U001' }) },
       ])
 
     const result = await cascadeRevertPerson('I001', AUTHOR)
-    expect(result).toMatchObject({ ok: false, status: 403, error: 'blocked' })
+    expect(result).toMatchObject({ ok: false, status: 403, error: 'Blocked by foreign connection' })
     const blocked = (result as Extract<typeof result, { ok: false }>).blockedBy
     expect(blocked).toHaveLength(1)
     expect(blocked![0]).toMatchObject({ unionId: 'U001', authorEmail: 'bob@example.com' })
@@ -83,6 +101,7 @@ describe('cascadeRevertPerson — with unions', () => {
     mockRead
       .mockResolvedValueOnce([{ ...CREATE_ROW, authorEmail: 'admin@example.com' }])
       .mockResolvedValueOnce([{ unionId: 'U001' }])
+      .mockResolvedValueOnce(PERSON_EXISTS)
       .mockResolvedValueOnce([
         { id: 'rel1', authorEmail: 'bob@example.com', authorName: 'Bob', newValue: JSON.stringify({ unionId: 'U001' }) },
       ])
@@ -96,6 +115,7 @@ describe('cascadeRevertPerson — with unions', () => {
     mockRead
       .mockResolvedValueOnce([CREATE_ROW])
       .mockResolvedValueOnce([{ unionId: 'U001' }])
+      .mockResolvedValueOnce(PERSON_EXISTS)
       .mockResolvedValueOnce([
         { id: 'rel1', authorEmail: 'alice@example.com', authorName: 'Alice', newValue: JSON.stringify({ unionId: 'U001' }) },
       ])
@@ -112,6 +132,7 @@ describe('cascadeRevertPerson — child-edge union discovery', () => {
     mockRead
       .mockResolvedValueOnce([CREATE_ROW])
       .mockResolvedValueOnce([{ unionId: 'U_CHILD' }]) // returned by the fixed query
+      .mockResolvedValueOnce(PERSON_EXISTS)
       .mockResolvedValueOnce([
         { id: 'rel2', authorEmail: 'alice@example.com', authorName: 'Alice', newValue: JSON.stringify({ unionId: 'U_CHILD' }) },
       ])
@@ -131,9 +152,43 @@ describe('cascadeRevertPerson — malformed change record', () => {
     mockRead
       .mockResolvedValueOnce([{ ...CREATE_ROW, newValue: 'not-json' }])
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(PERSON_EXISTS)
 
     const result = await cascadeRevertPerson('I001', AUTHOR)
     expect(result).toEqual({ ok: false, status: 409, error: expect.any(String) })
+    expect(mockWriteTransaction).not.toHaveBeenCalled()
+  })
+})
+
+describe('cascadeRevertPerson — database errors', () => {
+  it('returns 500 with "Database error" when the initial reads throw', async () => {
+    mockRead.mockRejectedValueOnce(new Error('Neo4j unreachable'))
+
+    const result = await cascadeRevertPerson('I001', AUTHOR)
+    expect(result).toEqual({ ok: false, status: 500, error: 'Database error' })
+    expect(mockWriteTransaction).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 with "Database error" when writeTransaction throws', async () => {
+    mockRead
+      .mockResolvedValueOnce([CREATE_ROW])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(PERSON_EXISTS)
+    mockWriteTransaction.mockRejectedValueOnce(new Error('transaction failed'))
+
+    const result = await cascadeRevertPerson('I001', AUTHOR)
+    expect(result).toEqual({ ok: false, status: 500, error: 'Database error' })
+  })
+
+  it('returns 500 with "Database error" when the union relation read throws', async () => {
+    mockRead
+      .mockResolvedValueOnce([CREATE_ROW])
+      .mockResolvedValueOnce([{ unionId: 'U001' }])
+      .mockResolvedValueOnce(PERSON_EXISTS)
+      .mockRejectedValueOnce(new Error('Neo4j unreachable'))
+
+    const result = await cascadeRevertPerson('I001', AUTHOR)
+    expect(result).toEqual({ ok: false, status: 500, error: 'Database error' })
     expect(mockWriteTransaction).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/cascade-revert.ts
+++ b/src/lib/cascade-revert.ts
@@ -10,7 +10,7 @@ const CHANGE_TYPE = {
 
 export type CascadeRevertOutcome =
   | { ok: true; unionsReverted: number }
-  | { ok: false; status: 403 | 404 | 409; error: string; blockedBy?: BlockedEdge[] }
+  | { ok: false; status: 403 | 404 | 409 | 500; error: string; blockedBy?: BlockedEdge[] }
 
 export interface BlockedEdge {
   unionId: string
@@ -38,19 +38,38 @@ export async function cascadeRevertPerson(
        RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
        LIMIT 1`
 
-  const [createRows, unionRows] = await Promise.all([
-    read<ChangeQueryRow>(
-      createQueryCypher,
-      { personId, email: requester.email, createType: CHANGE_TYPE.CREATE_PERSON, live: CHANGE_STATUS.LIVE }
-    ),
-    read<{ unionId: string }>(
-      `MATCH (p:Person {gedcomId: $personId})
-       MATCH (u:Union) WHERE (p)-[:UNION]->(u) OR (u)-[:CHILD]->(p)
-       RETURN DISTINCT u.gedcomId AS unionId
-       LIMIT 100`,
-      { personId }
-    ), // Limits reverting to people with ≤100 unions
-  ])
+  let createRows: ChangeQueryRow[]
+  let unionRows: { unionId: string }[]
+  let personExists: boolean
+
+  try {
+    const [cr, ur, pr] = await Promise.all([
+      read<ChangeQueryRow>(
+        createQueryCypher,
+        { personId, email: requester.email, createType: CHANGE_TYPE.CREATE_PERSON, live: CHANGE_STATUS.LIVE }
+      ),
+      read<{ unionId: string }>(
+        `MATCH (p:Person {gedcomId: $personId})
+         MATCH (u:Union) WHERE (p)-[:UNION]->(u) OR (u)-[:CHILD]->(p)
+         RETURN DISTINCT u.gedcomId AS unionId
+         LIMIT 100`,
+        { personId }
+      ), // Limits reverting to people with ≤100 unions
+      read<{ exists: boolean }>(
+        `MATCH (p:Person {gedcomId: $personId}) RETURN true AS exists LIMIT 1`,
+        { personId }
+      ),
+    ])
+    createRows = cr
+    unionRows = ur
+    personExists = pr.length > 0
+  } catch {
+    return { ok: false, status: 500, error: 'Database error' }
+  }
+
+  if (!personExists) {
+    return { ok: false, status: 404, error: 'Person not found' }
+  }
 
   if (createRows.length === 0) {
     return { ok: false, status: 404, error: 'No CREATE_PERSON change found for this person' }
@@ -72,14 +91,19 @@ export async function cascadeRevertPerson(
   const relChangesByUnion = new Map<string, { id: string; authorEmail: string; authorName: string }>()
 
   if (unionIds.length > 0) {
-    const allRelRows = await read<ChangeQueryRow>(
-      `MATCH (c:Change { changeType: $relType, status: $live })
-       WHERE any(uid IN $unionIds WHERE c.newValue CONTAINS uid)
-       RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
-       LIMIT toInteger($limit)`,
-      // Each union produces one ADD_RELATIONSHIP change; multiply by 2 as a safety margin for retries or dual-direction entries.
-      { unionIds, relType: CHANGE_TYPE.ADD_RELATIONSHIP, live: CHANGE_STATUS.LIVE, limit: unionIds.length * 2 }
-    )
+    let allRelRows: ChangeQueryRow[]
+    try {
+      allRelRows = await read<ChangeQueryRow>(
+        `MATCH (c:Change { changeType: $relType, status: $live })
+         WHERE any(uid IN $unionIds WHERE c.newValue CONTAINS uid)
+         RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
+         LIMIT toInteger($limit)`,
+        // Each union produces one ADD_RELATIONSHIP change; multiply by 2 as a safety margin for retries or dual-direction entries.
+        { unionIds, relType: CHANGE_TYPE.ADD_RELATIONSHIP, live: CHANGE_STATUS.LIVE, limit: unionIds.length * 2 }
+      )
+    } catch {
+      return { ok: false, status: 500, error: 'Database error' }
+    }
 
     const unionIdSet = new Set(unionIds)
     for (const row of allRelRows) {
@@ -111,7 +135,7 @@ export async function cascadeRevertPerson(
         }
       }
       if (blockedBy.length > 0) {
-        return { ok: false, status: 403, error: 'blocked', blockedBy }
+        return { ok: false, status: 403, error: 'Blocked by foreign connection', blockedBy }
       }
     }
   }
@@ -140,9 +164,8 @@ export async function cascadeRevertPerson(
 
   try {
     await writeTransaction(statements)
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    return { ok: false, status: 409, error: `Failed to write revert transaction: ${message}` }
+  } catch {
+    return { ok: false, status: 500, error: 'Database error' }
   }
 
   try {

--- a/src/lib/cascade-revert.ts
+++ b/src/lib/cascade-revert.ts
@@ -29,13 +29,19 @@ export async function cascadeRevertPerson(
   personId: string,
   requester: { email: string; name: string; isAdmin: boolean }
 ): Promise<CascadeRevertOutcome> {
+  const createQueryCypher = requester.isAdmin
+    ? `MATCH (c:Change { changeType: $createType, status: $live, targetId: $personId })
+       RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
+       LIMIT 1`
+    : `MATCH (c:Change { changeType: $createType, status: $live, targetId: $personId })
+       WHERE toLower(c.authorEmail) = toLower($email)
+       RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
+       LIMIT 1`
+
   const [createRows, unionRows] = await Promise.all([
     read<ChangeQueryRow>(
-      `MATCH (c:Change { changeType: $createType, status: $live, targetId: $personId })
-       WHERE $isAdmin OR toLower(c.authorEmail) = toLower($email)
-       RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
-       LIMIT 1`,
-      { personId, email: requester.email, isAdmin: requester.isAdmin, createType: CHANGE_TYPE.CREATE_PERSON, live: CHANGE_STATUS.LIVE }
+      createQueryCypher,
+      { personId, email: requester.email, createType: CHANGE_TYPE.CREATE_PERSON, live: CHANGE_STATUS.LIVE }
     ),
     read<{ unionId: string }>(
       `MATCH (p:Person {gedcomId: $personId})
@@ -70,7 +76,7 @@ export async function cascadeRevertPerson(
       `MATCH (c:Change { changeType: $relType, status: $live })
        WHERE any(uid IN $unionIds WHERE c.newValue CONTAINS uid)
        RETURN c.id AS id, c.authorEmail AS authorEmail, c.authorName AS authorName, c.newValue AS newValue
-       LIMIT $limit`,
+       LIMIT toInteger($limit)`,
       // Each union produces one ADD_RELATIONSHIP change; multiply by 2 as a safety margin for retries or dual-direction entries.
       { unionIds, relType: CHANGE_TYPE.ADD_RELATIONSHIP, live: CHANGE_STATUS.LIVE, limit: unionIds.length * 2 }
     )
@@ -132,7 +138,12 @@ export async function cascadeRevertPerson(
     { cypher: `MATCH (c:Change {id: $id}) SET c.status = $reverted`, params: { id: createChange.id, reverted: CHANGE_STATUS.REVERTED } }
   )
 
-  await writeTransaction(statements)
+  try {
+    await writeTransaction(statements)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, status: 409, error: `Failed to write revert transaction: ${message}` }
+  }
 
   try {
     await recordChange(requester.email, requester.name, CHANGE_TYPE.DELETE_PERSON, personId, prevFromCreate, {})

--- a/tests/e2e/cascade-revert.spec.ts
+++ b/tests/e2e/cascade-revert.spec.ts
@@ -1,18 +1,48 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type BrowserContext } from '@playwright/test'
+import { encode } from '@auth/core/jwt'
 import { mockPersonsAndTree, mockSignedInSession } from './helpers/revert-mocks'
 
 /**
- * E2E tests for the cascade-revert flow (issue #119).
+ * E2E tests for the cascade-revert flow (issue #127).
  *
  * Scenarios:
- *   1. Happy path — person with relationships; user is the author of all connections.
- *      Click delete → confirm cascade dialog → POST /api/person/[id]/cascade-revert →
- *      drawer closes and tree refreshes.
- *   2. Blocked path — some connections were added by another user.
- *      POST returns 403 with blockedBy; "Contact an admin" message is shown inline.
+ *   1. Admin deletes a person they created (with connections they also created) →
+ *      cascade-revert is called, drawer closes, person removed from tree.
+ *   2. Non-admin deletes a person they created with no connections →
+ *      simple /api/changes/[id]/revert is called, drawer closes (success).
+ *   3. Non-admin attempt where another user added a connection →
+ *      delete button is pre-disabled and error message is shown inline.
  */
 
-const mockAlice = {
+// ── Admin auth helper ────────────────────────────────────────────────────────
+
+async function setAdminCookie(context: BrowserContext): Promise<void> {
+  const token = await encode({
+    token: {
+      name: 'E2E Admin',
+      email: 'admin@test.com',
+      picture: null,
+      sub: 'e2e-admin-001',
+      role: 'admin',
+    },
+    secret: process.env.AUTH_SECRET ?? 'e2e-test-auth-secret',
+    salt: 'authjs.session-token',
+  })
+  await context.addCookies([{
+    name: 'authjs.session-token',
+    value: token,
+    domain: 'localhost',
+    path: '/',
+    httpOnly: true,
+    secure: false,
+    sameSite: 'Lax',
+  }])
+}
+
+// ── Shared mock data ─────────────────────────────────────────────────────────
+
+// Alice with one parent — used in admin test (scenario 1) and foreign-connection test (scenario 3)
+const mockAliceWithParent = {
   gedcomId: '@IALICE@',
   name: 'Alice Connected',
   sex: 'F',
@@ -27,32 +57,68 @@ const mockAlice = {
   marriages: [],
 }
 
-const aliceTreeResponse = {
-  nodes: [
-    {
-      id: 'node-@IALICE@',
-      type: 'person',
-      data: {
-        gedcomId: '@IALICE@',
-        name: 'Alice Connected',
-        sex: 'F',
-        birthYear: '1990',
-        deathYear: null,
-        birthPlace: null,
-        deathPlace: null,
-        occupation: null,
-        notes: null,
-        isRoot: true,
-        generation: 0,
-      },
-      position: { x: 0, y: 0 },
+// Alice with no connections — used in non-admin simple-revert test (scenario 2)
+const mockAliceNoConnections = {
+  gedcomId: '@IALICE@',
+  name: 'Alice Simple',
+  sex: 'F',
+  birthYear: '1990',
+  deathYear: null,
+  birthPlace: null,
+  deathPlace: null,
+  occupation: null,
+  notes: null,
+  parents: [],
+  siblings: [],
+  marriages: [],
+}
+
+const aliceWithParentTreeResponse = {
+  nodes: [{
+    id: 'node-@IALICE@',
+    type: 'person',
+    data: {
+      gedcomId: '@IALICE@',
+      name: 'Alice Connected',
+      sex: 'F',
+      birthYear: '1990',
+      deathYear: null,
+      birthPlace: null,
+      deathPlace: null,
+      occupation: null,
+      notes: null,
+      isRoot: true,
+      generation: 0,
     },
-  ],
+    position: { x: 0, y: 0 },
+  }],
   edges: [],
 }
 
-// Happy path: user authored all connections (1 relationship change matches 1 parent)
-const myChangesWithRelationship = {
+const aliceSimpleTreeResponse = {
+  nodes: [{
+    id: 'node-@IALICE@',
+    type: 'person',
+    data: {
+      gedcomId: '@IALICE@',
+      name: 'Alice Simple',
+      sex: 'F',
+      birthYear: '1990',
+      deathYear: null,
+      birthPlace: null,
+      deathPlace: null,
+      occupation: null,
+      notes: null,
+      isRoot: true,
+      generation: 0,
+    },
+    position: { x: 0, y: 0 },
+  }],
+  edges: [],
+}
+
+// Admin's my-changes: created Alice and added the parent relationship themselves
+const adminChangesWithRelationship = {
   createChange: {
     id: 'change-create-1',
     changeType: 'CREATE_PERSON',
@@ -61,45 +127,46 @@ const myChangesWithRelationship = {
     appliedAt: '2026-04-01T10:00:00.000Z',
   },
   relationshipChanges: [
-    { id: 'change-rel-1', newValue: { unionId: '@UBOB@' }, appliedAt: '2026-04-01T10:00:00.000Z' },
+    { id: 'change-rel-1', newValue: { unionId: '@UBOB@' }, appliedAt: '2026-04-01T10:01:00.000Z' },
   ],
   updateChanges: [],
 }
 
-// Blocked path: user authored no relationship changes, but Alice has 1 parent
-// → hasForeignConnections = true → button pre-disabled without a server round-trip
-const myChangesWithCreate = {
+// Non-admin's my-changes: created Alice, owns no relationship changes
+// Used for both scenario 2 (Alice has no connections) and scenario 3 (another user added them)
+const userChangesCreateOnly = {
   createChange: {
-    id: 'change-create-1',
+    id: 'change-create-2',
     changeType: 'CREATE_PERSON',
     targetId: '@IALICE@',
-    newValue: { name: 'Alice Connected' },
+    newValue: { name: 'Alice Simple' },
     appliedAt: '2026-04-01T10:00:00.000Z',
   },
   relationshipChanges: [],
   updateChanges: [],
 }
 
-const alicePersonsList = [
-  { gedcomId: '@IALICE@', name: 'Alice Connected', sex: 'F', birthYear: '1990', deathYear: null, birthPlace: null },
-]
+// ── Tests ────────────────────────────────────────────────────────────────────
 
-test.describe('cascade-revert: delete person with connections', () => {
-  test('happy path — cascade-revert called, drawer closes on success', async ({ page }) => {
+test.describe('cascade-revert: delete person', () => {
+  test('admin deletes a person they created with connections they also created — person removed from tree, success shown', async ({ page, context }) => {
     let cascadePostCount = 0
 
-    await mockSignedInSession(page)
-    await mockPersonsAndTree(page, alicePersonsList, aliceTreeResponse)
+    await setAdminCookie(context)
+    await mockPersonsAndTree(page,
+      [{ gedcomId: '@IALICE@', name: 'Alice Connected', sex: 'F', birthYear: '1990', deathYear: null, birthPlace: null }],
+      aliceWithParentTreeResponse,
+    )
 
-    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(myChangesWithRelationship),
+        body: JSON.stringify(adminChangesWithRelationship),
       })
     )
 
-    await page.route(/\/api\/person\/[^/]+\/cascade-revert/, async (route) => {
+    await page.route(/\/api\/person\/[^/]+\/cascade-revert/, async route => {
       if (route.request().method() === 'POST') {
         cascadePostCount += 1
         await route.fulfill({
@@ -112,11 +179,11 @@ test.describe('cascade-revert: delete person with connections', () => {
       await route.continue()
     })
 
-    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+    await page.route(/\/api\/person\/[^/]+$/, route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(mockAlice),
+        body: JSON.stringify(mockAliceWithParent),
       })
     )
 
@@ -135,7 +202,7 @@ test.describe('cascade-revert: delete person with connections', () => {
     await expect(deleteBtn).toBeVisible()
     await expect(deleteBtn).toBeEnabled()
 
-    page.once('dialog', (d) => {
+    page.once('dialog', d => {
       expect(d.message()).toMatch(/1.*connections?/i)
       d.accept()
     })
@@ -145,26 +212,86 @@ test.describe('cascade-revert: delete person with connections', () => {
     expect(cascadePostCount).toBe(1)
   })
 
-  test('blocked path — button pre-disabled when foreign connections exist', async ({ page }) => {
-    // myChangesWithCreate has 0 relationship changes but Alice has 1 parent connection.
-    // The client-side count comparison detects this and disables the button immediately,
-    // showing the "contact an admin" message without a server round-trip.
-    await mockSignedInSession(page)
-    await mockPersonsAndTree(page, alicePersonsList, aliceTreeResponse)
+  test('non-admin deletes a person they created with no connections — success', async ({ page }) => {
+    let revertPostCount = 0
 
-    await page.route(/\/api\/person\/[^/]+\/my-changes/, (route) =>
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page,
+      [{ gedcomId: '@IALICE@', name: 'Alice Simple', sex: 'F', birthYear: '1990', deathYear: null, birthPlace: null }],
+      aliceSimpleTreeResponse,
+    )
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(myChangesWithCreate),
+        body: JSON.stringify(userChangesCreateOnly),
       })
     )
 
-    await page.route(/\/api\/person\/[^/]+$/, (route) =>
+    await page.route(/\/api\/person\/[^/]+$/, route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(mockAlice),
+        body: JSON.stringify(mockAliceNoConnections),
+      })
+    )
+
+    await page.route(/\/api\/changes\/[^/]+\/revert/, async route => {
+      if (route.request().method() === 'POST') {
+        revertPostCount += 1
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('toolbar-viewing')).toContainText('Alice', { timeout: 15_000 })
+
+    const personNode = page.locator('.react-flow__node-person').first()
+    await expect(personNode).toBeVisible({ timeout: 10_000 })
+    await personNode.click()
+
+    const drawer = page.getByTestId('person-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(page.getByTestId('person-drawer-marriages')).toBeVisible({ timeout: 5_000 })
+
+    const deleteBtn = page.getByTestId('person-drawer-delete')
+    await expect(deleteBtn).toBeVisible()
+    await expect(deleteBtn).toBeEnabled()
+
+    page.once('dialog', d => d.accept())
+    await deleteBtn.click()
+
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 })
+    expect(revertPostCount).toBe(1)
+  })
+
+  test('non-admin attempt where another user added a connection — error message shown', async ({ page }) => {
+    await mockSignedInSession(page)
+    await mockPersonsAndTree(page,
+      [{ gedcomId: '@IALICE@', name: 'Alice Connected', sex: 'F', birthYear: '1990', deathYear: null, birthPlace: null }],
+      aliceWithParentTreeResponse,
+    )
+
+    await page.route(/\/api\/person\/[^/]+\/my-changes/, route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(userChangesCreateOnly),
+      })
+    )
+
+    await page.route(/\/api\/person\/[^/]+$/, route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockAliceWithParent),
       })
     )
 
@@ -183,8 +310,7 @@ test.describe('cascade-revert: delete person with connections', () => {
     await expect(deleteBtn).toBeVisible()
     await expect(deleteBtn).toBeDisabled()
 
-    const errorMsg = page.getByTestId('person-drawer-action-error')
-    await expect(errorMsg).toContainText(/admin/i, { timeout: 5_000 })
+    await expect(page.getByTestId('person-drawer-action-error')).toContainText(/admin/i, { timeout: 5_000 })
     await expect(drawer).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

- **Task 1**: Add `console.error` logging in the cascade-revert catch block so unhandled exceptions surface in server logs
- **Task 2**: Fix three root causes in `cascadeRevertPerson`: split the boolean Cypher parameter (`WHERE $isAdmin OR ...`) into two conditional query strings; add `toInteger()` around the `LIMIT $limit` parameter; wrap `writeTransaction` in try/catch returning a structured error outcome instead of propagating exceptions
- **Task 3**: Return meaningful HTTP error responses — `404 "Person not found"`, `404 "No CREATE_PERSON change found"`, `403 "Blocked by foreign connection"`, `500 "Database error"` — with updated unit tests (18 passing)
- **Task 4**: Rewrite `tests/e2e/cascade-revert.spec.ts` with three role-based scenarios: admin deletes own person with own connections (success), non-admin deletes own isolated person (success), non-admin blocked by foreign connection (error shown)

Fixes #127

## Test plan
- [x] 18 cascade-revert unit tests passing (both lib and route)
- [x] Pre-existing failing tests (`neo4j.test.ts`, `middleware.test.ts`, `tree/route.test.ts`, `admin/suggestions/route.test.ts`) are unchanged from main — not introduced by this PR
- [x] E2E spec updated with three role-based scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)