### PR TITLE
feat(issue-146): add public relationship shortest-path endpoint with kinship naming

### DIFF
--- a/src/app/api/relationship/route.test.ts
+++ b/src/app/api/relationship/route.test.ts
@@ -100,6 +100,28 @@ describe('GET /api/relationship', () => {
     })
   })
 
+  describe('same person', () => {
+    it('returns a self label with no steps when from and to are the same existing person', async () => {
+      mockRead.mockResolvedValue([{ exists: true }])
+
+      const response = await GET(makeRequest('?from=I001&to=I001'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ from: 'I001', to: 'I001', steps: [], label: 'self' })
+    })
+
+    it('returns 404 when from and to are the same but the person does not exist', async () => {
+      mockRead.mockResolvedValue([{ exists: false }])
+
+      const response = await GET(makeRequest('?from=MISSING&to=MISSING'))
+      const body = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(body).toEqual({ error: 'Person not found' })
+    })
+  })
+
   describe('no path within bound', () => {
     it('returns 404 when both people exist but no path was found', async () => {
       mockRead.mockResolvedValue([{ fromExists: true, toExists: true, nodes: null, rels: null }])

--- a/src/app/api/relationship/route.test.ts
+++ b/src/app/api/relationship/route.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for GET /api/relationship.
+ *
+ * The Neo4j `read` helper is mocked so tests verify the route's own
+ * responsibilities in isolation: query-parameter validation, the
+ * fromExists/toExists/no-path 404 branches, walking a shortest-path row into
+ * kinship steps, and the computed label — without needing a real database.
+ */
+import { GET } from './route'
+
+jest.mock('@/lib/neo4j', () => ({
+  read: jest.fn(),
+  neo4jErrorResponse: jest.fn((err: unknown, publicMessage: string, status = 500) => {
+    const detail = err instanceof Error ? err.message : String(err)
+    return Response.json({ error: publicMessage, detail }, { status })
+  }),
+}))
+
+import { read } from '@/lib/neo4j'
+const mockRead = read as jest.MockedFunction<typeof read>
+
+const makeRequest = (query: string) => new Request(`http://localhost/api/relationship${query}`)
+
+const personNode = (gedcomId: string, name: string, sex: string | null) => ({
+  _id: `node:${gedcomId}`,
+  _labels: ['Person'],
+  gedcomId,
+  name,
+  sex,
+})
+
+const unionNode = (gedcomId: string) => ({
+  _id: `node:${gedcomId}`,
+  _labels: ['Union'],
+  gedcomId,
+})
+
+describe('GET /api/relationship', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('invalid params', () => {
+    it('returns 400 when the from param is missing', async () => {
+      const response = await GET(makeRequest('?to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body).toEqual({ error: 'from and to query parameters are required' })
+      expect(mockRead).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when the to param is missing', async () => {
+      const response = await GET(makeRequest('?from=I001'))
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body).toEqual({ error: 'from and to query parameters are required' })
+      expect(mockRead).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when both params are missing', async () => {
+      const response = await GET(makeRequest(''))
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body).toEqual({ error: 'from and to query parameters are required' })
+    })
+  })
+
+  describe('unknown person', () => {
+    it('returns 404 when the from person does not exist', async () => {
+      mockRead.mockResolvedValue([{ fromExists: false, toExists: true, nodes: null, rels: null }])
+
+      const response = await GET(makeRequest('?from=MISSING&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(body).toEqual({ error: 'Person not found' })
+    })
+
+    it('returns 404 when the to person does not exist', async () => {
+      mockRead.mockResolvedValue([{ fromExists: true, toExists: false, nodes: null, rels: null }])
+
+      const response = await GET(makeRequest('?from=I001&to=MISSING'))
+      const body = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(body).toEqual({ error: 'Person not found' })
+    })
+
+    it('returns 404 when neither person exists', async () => {
+      mockRead.mockResolvedValue([{ fromExists: false, toExists: false, nodes: null, rels: null }])
+
+      const response = await GET(makeRequest('?from=MISSING1&to=MISSING2'))
+      const body = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(body).toEqual({ error: 'Person not found' })
+    })
+  })
+
+  describe('no path within bound', () => {
+    it('returns 404 when both people exist but no path was found', async () => {
+      mockRead.mockResolvedValue([{ fromExists: true, toExists: true, nodes: null, rels: null }])
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(body).toEqual({ error: 'No relationship path found within 20 hops' })
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns 200 with the classified step sequence and computed label for a parent hop', async () => {
+      const child = personNode('I001', 'Child', 'M')
+      const union = unionNode('F001')
+      const father = personNode('I002', 'Father', 'M')
+
+      mockRead.mockResolvedValue([
+        {
+          fromExists: true,
+          toExists: true,
+          nodes: [child, union, father],
+          // child is born of the union; father is a partner in the union
+          rels: [
+            { type: 'CHILD', start: union._id, end: child._id },
+            { type: 'UNION', start: father._id, end: union._id },
+          ],
+        },
+      ])
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        from: 'I001',
+        to: 'I002',
+        steps: [{ type: 'parent', name: 'Father', sex: 'M' }],
+        label: 'father',
+      })
+    })
+
+    it('returns 200 with a spouse step and label for a direct union hop', async () => {
+      const a = personNode('I001', 'A', 'F')
+      const union = unionNode('F001')
+      const b = personNode('I002', 'B', 'M')
+
+      mockRead.mockResolvedValue([
+        {
+          fromExists: true,
+          toExists: true,
+          nodes: [a, union, b],
+          rels: [
+            { type: 'UNION', start: a._id, end: union._id },
+            { type: 'UNION', start: b._id, end: union._id },
+          ],
+        },
+      ])
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.steps).toEqual([{ type: 'spouse', name: 'B', sex: 'M' }])
+      expect(body.label).toBe('husband')
+    })
+
+    it('expands a shared-union sibling crossing into a parent step then a child step', async () => {
+      const sister = personNode('I001', 'Sister', 'F')
+      const union = unionNode('F001')
+      const brother = personNode('I002', 'Brother', 'M')
+
+      mockRead.mockResolvedValue([
+        {
+          fromExists: true,
+          toExists: true,
+          nodes: [sister, union, brother],
+          // both are children of the same union -> siblings
+          rels: [
+            { type: 'CHILD', start: union._id, end: sister._id },
+            { type: 'CHILD', start: union._id, end: brother._id },
+          ],
+        },
+      ])
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.steps).toEqual([{ type: 'parent' }, { type: 'child', name: 'Brother', sex: 'M' }])
+      expect(body.label).toBe('brother')
+    })
+
+    it('passes from and to through to the Neo4j read call', async () => {
+      mockRead.mockResolvedValue([{ fromExists: true, toExists: true, nodes: null, rels: null }])
+
+      await GET(makeRequest('?from=I001&to=I002'))
+
+      expect(mockRead).toHaveBeenCalledWith(expect.any(String), { from: 'I001', to: 'I002' })
+    })
+
+    it('defaults a missing name and sex to empty string / null on step persons', async () => {
+      const child = { _id: 'node:I001', _labels: ['Person'], gedcomId: 'I001' }
+      const union = unionNode('F001')
+      const father = { _id: 'node:I002', _labels: ['Person'], gedcomId: 'I002' }
+
+      mockRead.mockResolvedValue([
+        {
+          fromExists: true,
+          toExists: true,
+          nodes: [child, union, father],
+          rels: [
+            { type: 'CHILD', start: union._id, end: child._id },
+            { type: 'UNION', start: father._id, end: union._id },
+          ],
+        },
+      ])
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(body.steps[0]).toEqual({ type: 'parent', name: '', sex: null })
+    })
+  })
+
+  describe('error handling', () => {
+    it('returns 500 when the Neo4j query throws', async () => {
+      mockRead.mockRejectedValue(new Error('Connection refused'))
+      jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({ error: 'Failed to query graph database', detail: 'Connection refused' })
+    })
+
+    it('returns 500 when the path cannot be classified into known steps', async () => {
+      const a = personNode('I001', 'A', 'F')
+      const union = unionNode('F001')
+      const b = personNode('I002', 'B', 'M')
+
+      mockRead.mockResolvedValue([
+        {
+          fromExists: true,
+          toExists: true,
+          nodes: [a, union, b],
+          // Neither relationship matches a partner/child pattern through the union.
+          rels: [
+            { type: 'CHILD', start: a._id, end: union._id },
+            { type: 'CHILD', start: b._id, end: union._id + 'x' },
+          ],
+        },
+      ])
+      jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      const response = await GET(makeRequest('?from=I001&to=I002'))
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body.error).toBe('Failed to classify relationship path')
+    })
+  })
+})

--- a/src/app/api/relationship/route.ts
+++ b/src/app/api/relationship/route.ts
@@ -1,0 +1,198 @@
+/**
+ * @module api/relationship
+ * @description Public Next.js App Router route handler that computes the shortest
+ * kinship path between two people in the family graph and a human-readable label
+ * describing how they are related (e.g. "first cousin once removed").
+ */
+
+import { read, neo4jErrorResponse } from '@/lib/neo4j'
+import { computeKinshipLabel, type KinshipStep } from '@/lib/kinship'
+
+/** Force Node.js runtime so the Neo4j driver can open TCP connections. */
+export const runtime = 'nodejs'
+
+/** Hard cap on the number of `UNION`/`CHILD` relationship hops the shortest-path search may traverse. */
+const MAX_RELATIONSHIP_HOPS = 20
+
+/**
+ * Raw shape of a graph node on the shortest path, as returned by the Neo4j query.
+ * Path nodes alternate `Person`, `Union`, `Person`, ... between the two endpoints.
+ *
+ * @interface Neo4jPathNode
+ */
+interface Neo4jPathNode {
+  _id: string
+  _labels: string[]
+  gedcomId: string
+  name?: string
+  sex?: string | null
+}
+
+/**
+ * Raw shape of a graph relationship on the shortest path.
+ * `start`/`end` are element IDs corresponding to {@link Neo4jPathNode._id}, reflecting
+ * the relationship's true stored direction (not the direction it was traversed in).
+ *
+ * @interface Neo4jPathRel
+ */
+interface Neo4jPathRel {
+  type: string
+  start: string
+  end: string
+}
+
+/** Row shape returned by the shortest-path Cypher query. */
+interface RelationshipPathRow {
+  fromExists: boolean
+  toExists: boolean
+  nodes: Neo4jPathNode[] | null
+  rels: Neo4jPathRel[] | null
+}
+
+/** Response payload for `GET /api/relationship`. */
+interface RelationshipResponse {
+  from: string
+  to: string
+  steps: KinshipStep[]
+  label: string
+}
+
+/**
+ * Error thrown when a path's relationship structure does not match any known
+ * `UNION`/`CHILD` pattern. Should be unreachable given the graph model, but guards
+ * against silently mislabeling a step if the schema ever changes.
+ */
+class UnclassifiableStepError extends Error {}
+
+/**
+ * Classifies a single Union crossing between two adjacent Person nodes on the path
+ * into a {@link KinshipStep}.
+ *
+ * The family graph models a union as `(Person)-[:UNION]->(Union)` (partner in the
+ * union) and `(Union)-[:CHILD]->(Person)` (child born of the union). A shortest path
+ * walks `Person -> Union -> Person` for each step, so the pair of relationships either
+ * side of the Union node determines the relation:
+ * - prev is a partner in the union, next is a child of it  -> next is prev's `child`
+ * - prev is a child of the union, next is a partner in it  -> next is prev's `parent`
+ * - both prev and next are partners in the same union      -> next is prev's `spouse`
+ * - both prev and next are children of the same union      -> next is prev's `sibling`
+ */
+function classifyStep(
+  prev: Neo4jPathNode,
+  union: Neo4jPathNode,
+  next: Neo4jPathNode,
+  prevRel: Neo4jPathRel,
+  nextRel: Neo4jPathRel
+): KinshipStep {
+  const prevIsPartner = prevRel.type === 'UNION' && prevRel.start === prev._id && prevRel.end === union._id
+  const prevIsChild = prevRel.type === 'CHILD' && prevRel.start === union._id && prevRel.end === prev._id
+  const nextIsPartner = nextRel.type === 'UNION' && nextRel.start === next._id && nextRel.end === union._id
+  const nextIsChild = nextRel.type === 'CHILD' && nextRel.start === union._id && nextRel.end === next._id
+
+  let type: KinshipStep['type']
+  if (prevIsPartner && nextIsChild) {
+    type = 'child'
+  } else if (prevIsChild && nextIsPartner) {
+    type = 'parent'
+  } else if (prevIsPartner && nextIsPartner) {
+    type = 'spouse'
+  } else if (prevIsChild && nextIsChild) {
+    type = 'sibling'
+  } else {
+    throw new UnclassifiableStepError(
+      `Cannot classify step through union ${union.gedcomId}: ${prevRel.type} then ${nextRel.type}`
+    )
+  }
+
+  return {
+    type,
+    person: { gedcomId: next.gedcomId, name: next.name ?? '', sex: next.sex ?? null },
+  }
+}
+
+/**
+ * Walks a shortest path's alternating `Person, Union, Person, ...` node sequence and
+ * classifies each Union crossing into a {@link KinshipStep}.
+ */
+function classifySteps(nodes: Neo4jPathNode[], rels: Neo4jPathRel[]): KinshipStep[] {
+  const steps: KinshipStep[] = []
+  for (let i = 0; i + 2 < nodes.length; i += 2) {
+    steps.push(classifyStep(nodes[i], nodes[i + 1], nodes[i + 2], rels[i], rels[i + 1]))
+  }
+  return steps
+}
+
+/**
+ * Returns the shortest kinship path between two people and a human-readable label
+ * describing how they are related.
+ *
+ * Query Parameters:
+ * - `from` (required): GEDCOM ID of the first person
+ * - `to` (required): GEDCOM ID of the second person
+ *
+ * @async
+ * @param {Request} request - Incoming HTTP request; `from` and `to` query params identify the two people
+ * @returns {Promise<Response>} JSON `RelationshipResponse` on success, or error JSON with 400/404/500 status
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const from = url.searchParams.get('from')
+  const to = url.searchParams.get('to')
+
+  if (!from || !to) {
+    return Response.json({ error: 'from and to query parameters are required' }, { status: 400 })
+  }
+
+  let rows: RelationshipPathRow[]
+  try {
+    rows = await read<RelationshipPathRow>(
+      `OPTIONAL MATCH (a:Person {gedcomId: $from})
+       OPTIONAL MATCH (b:Person {gedcomId: $to})
+       CALL {
+         WITH a, b
+         WITH a, b WHERE a IS NOT NULL AND b IS NOT NULL
+         OPTIONAL MATCH p = shortestPath((a)-[:UNION|CHILD*..${MAX_RELATIONSHIP_HOPS}]-(b))
+         RETURN p
+       }
+       RETURN
+         a IS NOT NULL AS fromExists,
+         b IS NOT NULL AS toExists,
+         CASE WHEN p IS NULL THEN null ELSE
+           [n IN nodes(p) | {_id: elementId(n), _labels: labels(n), gedcomId: n.gedcomId, name: n.name, sex: n.sex}]
+         END AS nodes,
+         CASE WHEN p IS NULL THEN null ELSE
+           [r IN relationships(p) | {type: type(r), start: elementId(startNode(r)), end: elementId(endNode(r))}]
+         END AS rels`,
+      { from, to }
+    )
+  } catch (err) {
+    return neo4jErrorResponse(err, 'Failed to query graph database')
+  }
+
+  const row = rows[0]
+
+  if (!row?.fromExists || !row?.toExists) {
+    return Response.json({ error: 'Person not found' }, { status: 404 })
+  }
+
+  if (!row.nodes || !row.rels) {
+    return Response.json(
+      { error: `No relationship path found within ${MAX_RELATIONSHIP_HOPS} hops` },
+      { status: 404 }
+    )
+  }
+
+  let steps: KinshipStep[]
+  try {
+    steps = classifySteps(row.nodes, row.rels)
+  } catch (err) {
+    return neo4jErrorResponse(err, 'Failed to classify relationship path')
+  }
+
+  return Response.json({
+    from,
+    to,
+    steps,
+    label: computeKinshipLabel(steps),
+  } satisfies RelationshipResponse)
+}

--- a/src/app/api/relationship/route.ts
+++ b/src/app/api/relationship/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { read, neo4jErrorResponse } from '@/lib/neo4j'
-import { computeKinshipLabel, type KinshipStep } from '@/lib/kinship'
+import { computeKinshipLabel, type KinshipStep, type Sex } from '@/lib/kinship'
 
 /** Force Node.js runtime so the Neo4j driver can open TCP connections. */
 export const runtime = 'nodejs'
@@ -66,7 +66,7 @@ class UnclassifiableStepError extends Error {}
 
 /**
  * Classifies a single Union crossing between two adjacent Person nodes on the path
- * into a {@link KinshipStep}.
+ * into one or more {@link KinshipStep}s.
  *
  * The family graph models a union as `(Person)-[:UNION]->(Union)` (partner in the
  * union) and `(Union)-[:CHILD]->(Person)` (child born of the union). A shortest path
@@ -75,7 +75,9 @@ class UnclassifiableStepError extends Error {}
  * - prev is a partner in the union, next is a child of it  -> next is prev's `child`
  * - prev is a child of the union, next is a partner in it  -> next is prev's `parent`
  * - both prev and next are partners in the same union      -> next is prev's `spouse`
- * - both prev and next are children of the same union      -> next is prev's `sibling`
+ * - both prev and next are children of the same union      -> next is prev's sibling,
+ *   expressed as a `parent` hop up to the shared union followed by a `child` hop down
+ *   to `next`, since the {@link KinshipStep} vocabulary has no dedicated sibling type
  */
 function classifyStep(
   prev: Neo4jPathNode,
@@ -83,31 +85,30 @@ function classifyStep(
   next: Neo4jPathNode,
   prevRel: Neo4jPathRel,
   nextRel: Neo4jPathRel
-): KinshipStep {
+): KinshipStep[] {
   const prevIsPartner = prevRel.type === 'UNION' && prevRel.start === prev._id && prevRel.end === union._id
   const prevIsChild = prevRel.type === 'CHILD' && prevRel.start === union._id && prevRel.end === prev._id
   const nextIsPartner = nextRel.type === 'UNION' && nextRel.start === next._id && nextRel.end === union._id
   const nextIsChild = nextRel.type === 'CHILD' && nextRel.start === union._id && nextRel.end === next._id
 
-  let type: KinshipStep['type']
-  if (prevIsPartner && nextIsChild) {
-    type = 'child'
-  } else if (prevIsChild && nextIsPartner) {
-    type = 'parent'
-  } else if (prevIsPartner && nextIsPartner) {
-    type = 'spouse'
-  } else if (prevIsChild && nextIsChild) {
-    type = 'sibling'
-  } else {
-    throw new UnclassifiableStepError(
-      `Cannot classify step through union ${union.gedcomId}: ${prevRel.type} then ${nextRel.type}`
-    )
-  }
+  const name = next.name ?? ''
+  const sex = (next.sex ?? null) as Sex
 
-  return {
-    type,
-    person: { gedcomId: next.gedcomId, name: next.name ?? '', sex: next.sex ?? null },
+  if (prevIsPartner && nextIsChild) {
+    return [{ type: 'child', name, sex }]
   }
+  if (prevIsChild && nextIsPartner) {
+    return [{ type: 'parent', name, sex }]
+  }
+  if (prevIsPartner && nextIsPartner) {
+    return [{ type: 'spouse', name, sex }]
+  }
+  if (prevIsChild && nextIsChild) {
+    return [{ type: 'parent' }, { type: 'child', name, sex }]
+  }
+  throw new UnclassifiableStepError(
+    `Cannot classify step through union ${union.gedcomId}: ${prevRel.type} then ${nextRel.type}`
+  )
 }
 
 /**
@@ -117,7 +118,7 @@ function classifyStep(
 function classifySteps(nodes: Neo4jPathNode[], rels: Neo4jPathRel[]): KinshipStep[] {
   const steps: KinshipStep[] = []
   for (let i = 0; i + 2 < nodes.length; i += 2) {
-    steps.push(classifyStep(nodes[i], nodes[i + 1], nodes[i + 2], rels[i], rels[i + 1]))
+    steps.push(...classifyStep(nodes[i], nodes[i + 1], nodes[i + 2], rels[i], rels[i + 1]))
   }
   return steps
 }

--- a/src/app/api/relationship/route.ts
+++ b/src/app/api/relationship/route.ts
@@ -144,6 +144,29 @@ export async function GET(request: Request) {
     return Response.json({ error: 'from and to query parameters are required' }, { status: 400 })
   }
 
+  if (from === to) {
+    let existsRows: { exists: boolean }[]
+    try {
+      existsRows = await read<{ exists: boolean }>(
+        `OPTIONAL MATCH (a:Person {gedcomId: $from}) RETURN a IS NOT NULL AS exists`,
+        { from }
+      )
+    } catch (err) {
+      return neo4jErrorResponse(err, 'Failed to query graph database')
+    }
+
+    if (!existsRows[0]?.exists) {
+      return Response.json({ error: 'Person not found' }, { status: 404 })
+    }
+
+    return Response.json({
+      from,
+      to,
+      steps: [],
+      label: computeKinshipLabel([]),
+    } satisfies RelationshipResponse)
+  }
+
   let rows: RelationshipPathRow[]
   try {
     rows = await read<RelationshipPathRow>(

--- a/src/lib/kinship.test.ts
+++ b/src/lib/kinship.test.ts
@@ -1,0 +1,286 @@
+import { computeKinshipLabel, KinshipStep } from './kinship'
+
+function step(type: KinshipStep['type'], sex: KinshipStep['sex'] = null): KinshipStep {
+  return { type, sex }
+}
+
+describe('computeKinshipLabel — self', () => {
+  it('returns "self" for an empty step sequence', () => {
+    expect(computeKinshipLabel([])).toBe('self')
+  })
+})
+
+describe('computeKinshipLabel — parent', () => {
+  it('labels a male parent as father', () => {
+    expect(computeKinshipLabel([step('parent', 'M')])).toBe('father')
+  })
+
+  it('labels a female parent as mother', () => {
+    expect(computeKinshipLabel([step('parent', 'F')])).toBe('mother')
+  })
+
+  it('falls back to neutral "parent" when sex is unset', () => {
+    expect(computeKinshipLabel([step('parent', null)])).toBe('parent')
+  })
+})
+
+describe('computeKinshipLabel — grandparents and great-grandparents', () => {
+  it('labels two parent steps as grandfather/grandmother', () => {
+    expect(computeKinshipLabel([step('parent'), step('parent', 'M')])).toBe('grandfather')
+    expect(computeKinshipLabel([step('parent'), step('parent', 'F')])).toBe('grandmother')
+  })
+
+  it('labels three parent steps as great-grandparent', () => {
+    expect(computeKinshipLabel([step('parent'), step('parent'), step('parent', 'M')])).toBe(
+      'great-grandfather'
+    )
+  })
+
+  it('labels four parent steps as great-great-grandparent', () => {
+    expect(
+      computeKinshipLabel([step('parent'), step('parent'), step('parent'), step('parent', 'F')])
+    ).toBe('great-great-grandmother')
+  })
+
+  it('falls back to neutral "grandparent" when sex is unset', () => {
+    expect(computeKinshipLabel([step('parent'), step('parent', null)])).toBe('grandparent')
+  })
+})
+
+describe('computeKinshipLabel — child', () => {
+  it('labels a male child as son', () => {
+    expect(computeKinshipLabel([step('child', 'M')])).toBe('son')
+  })
+
+  it('labels a female child as daughter', () => {
+    expect(computeKinshipLabel([step('child', 'F')])).toBe('daughter')
+  })
+
+  it('falls back to neutral "child" when sex is unset', () => {
+    expect(computeKinshipLabel([step('child', null)])).toBe('child')
+  })
+})
+
+describe('computeKinshipLabel — grandchildren and great-grandchildren', () => {
+  it('labels two child steps as grandson/granddaughter', () => {
+    expect(computeKinshipLabel([step('child'), step('child', 'M')])).toBe('grandson')
+    expect(computeKinshipLabel([step('child'), step('child', 'F')])).toBe('granddaughter')
+  })
+
+  it('labels three child steps as great-grandchild', () => {
+    expect(computeKinshipLabel([step('child'), step('child'), step('child', 'F')])).toBe(
+      'great-granddaughter'
+    )
+  })
+})
+
+describe('computeKinshipLabel — siblings', () => {
+  it('labels an up-then-down path as brother', () => {
+    expect(computeKinshipLabel([step('parent'), step('child', 'M')])).toBe('brother')
+  })
+
+  it('labels an up-then-down path as sister', () => {
+    expect(computeKinshipLabel([step('parent'), step('child', 'F')])).toBe('sister')
+  })
+
+  it('falls back to neutral "sibling" when sex is unset', () => {
+    expect(computeKinshipLabel([step('parent'), step('child', null)])).toBe('sibling')
+  })
+})
+
+describe('computeKinshipLabel — uncle/aunt', () => {
+  it('labels a grandparent-then-down path as uncle', () => {
+    expect(computeKinshipLabel([step('parent'), step('parent'), step('child', 'M')])).toBe(
+      'uncle'
+    )
+  })
+
+  it('labels a grandparent-then-down path as aunt', () => {
+    expect(computeKinshipLabel([step('parent'), step('parent'), step('child', 'F')])).toBe('aunt')
+  })
+
+  it('labels a great-grandparent-then-down path as great-uncle', () => {
+    expect(
+      computeKinshipLabel([step('parent'), step('parent'), step('parent'), step('child', 'M')])
+    ).toBe('great-uncle')
+  })
+
+  it('labels a great-great-grandparent-then-down path as great-great-aunt', () => {
+    expect(
+      computeKinshipLabel([
+        step('parent'),
+        step('parent'),
+        step('parent'),
+        step('parent'),
+        step('child', 'F'),
+      ])
+    ).toBe('great-great-aunt')
+  })
+})
+
+describe('computeKinshipLabel — niece/nephew', () => {
+  it('labels an up-then-two-down path as nephew', () => {
+    expect(computeKinshipLabel([step('parent'), step('child'), step('child', 'M')])).toBe(
+      'nephew'
+    )
+  })
+
+  it('labels an up-then-two-down path as niece', () => {
+    expect(computeKinshipLabel([step('parent'), step('child'), step('child', 'F')])).toBe('niece')
+  })
+
+  it('labels an up-then-three-down path as grandnephew', () => {
+    expect(
+      computeKinshipLabel([step('parent'), step('child'), step('child'), step('child', 'M')])
+    ).toBe('grandnephew')
+  })
+
+  it('labels an up-then-four-down path as great-grandniece', () => {
+    expect(
+      computeKinshipLabel([
+        step('parent'),
+        step('child'),
+        step('child'),
+        step('child'),
+        step('child', 'F'),
+      ])
+    ).toBe('great-grandniece')
+  })
+})
+
+describe('computeKinshipLabel — cousins with generalized degree and removal', () => {
+  it('labels a two-up-two-down path as first cousin', () => {
+    expect(
+      computeKinshipLabel([step('parent'), step('parent'), step('child'), step('child', 'M')])
+    ).toBe('first cousin')
+  })
+
+  it('labels a two-up-three-down path as first cousin once removed', () => {
+    expect(
+      computeKinshipLabel([
+        step('parent'),
+        step('parent'),
+        step('child'),
+        step('child'),
+        step('child', 'F'),
+      ])
+    ).toBe('first cousin once removed')
+  })
+
+  it('labels a three-up-four-down path as second cousin once removed', () => {
+    expect(
+      computeKinshipLabel([
+        step('parent'),
+        step('parent'),
+        step('parent'),
+        step('child'),
+        step('child'),
+        step('child'),
+        step('child', 'M'),
+      ])
+    ).toBe('second cousin once removed')
+  })
+
+  it('labels a three-up-three-down path as second cousin', () => {
+    expect(
+      computeKinshipLabel([
+        step('parent'),
+        step('parent'),
+        step('parent'),
+        step('child'),
+        step('child'),
+        step('child', 'F'),
+      ])
+    ).toBe('second cousin')
+  })
+
+  it('labels a four-up-two-down path as first cousin twice removed', () => {
+    expect(
+      computeKinshipLabel([
+        step('parent'),
+        step('parent'),
+        step('parent'),
+        step('parent'),
+        step('child'),
+        step('child', 'M'),
+      ])
+    ).toBe('first cousin twice removed')
+  })
+
+  it('generalizes to a numbered ordinal cousin beyond the spelled-out range', () => {
+    const up = Array.from({ length: 12 }, () => step('parent'))
+    const down = Array.from({ length: 11 }, () => step('child'))
+    expect(computeKinshipLabel([...up, ...down, step('child', 'M')])).toBe('11th cousin')
+  })
+})
+
+describe('computeKinshipLabel — spouse', () => {
+  it('labels a single spouse step as husband', () => {
+    expect(computeKinshipLabel([step('spouse', 'M')])).toBe('husband')
+  })
+
+  it('labels a single spouse step as wife', () => {
+    expect(computeKinshipLabel([step('spouse', 'F')])).toBe('wife')
+  })
+
+  it('falls back to neutral "spouse" when sex is unset', () => {
+    expect(computeKinshipLabel([step('spouse', null)])).toBe('spouse')
+  })
+})
+
+describe('computeKinshipLabel — in-law and step relations', () => {
+  it('labels a spouse of a parent as stepfather/stepmother', () => {
+    expect(computeKinshipLabel([step('parent'), step('spouse', 'M')])).toBe('stepfather')
+    expect(computeKinshipLabel([step('parent'), step('spouse', 'F')])).toBe('stepmother')
+  })
+
+  it('labels a spouse of a child as son-in-law/daughter-in-law', () => {
+    expect(computeKinshipLabel([step('child'), step('spouse', 'M')])).toBe('son-in-law')
+    expect(computeKinshipLabel([step('child'), step('spouse', 'F')])).toBe('daughter-in-law')
+  })
+
+  it('labels a spouse of a sibling as brother-in-law/sister-in-law', () => {
+    expect(computeKinshipLabel([step('parent'), step('child'), step('spouse', 'M')])).toBe(
+      'brother-in-law'
+    )
+    expect(computeKinshipLabel([step('parent'), step('child'), step('spouse', 'F')])).toBe(
+      'sister-in-law'
+    )
+  })
+
+  it('labels a parent of a spouse as father-in-law/mother-in-law', () => {
+    expect(computeKinshipLabel([step('spouse'), step('parent', 'M')])).toBe('father-in-law')
+    expect(computeKinshipLabel([step('spouse'), step('parent', 'F')])).toBe('mother-in-law')
+  })
+
+  it('labels a child of a spouse as stepson/stepdaughter', () => {
+    expect(computeKinshipLabel([step('spouse'), step('child', 'M')])).toBe('stepson')
+    expect(computeKinshipLabel([step('spouse'), step('child', 'F')])).toBe('stepdaughter')
+  })
+
+  it('labels a sibling of a spouse as brother-in-law/sister-in-law', () => {
+    expect(computeKinshipLabel([step('spouse'), step('parent'), step('child', 'M')])).toBe(
+      'brother-in-law'
+    )
+  })
+
+  it('falls back to "by marriage" for uncommon in-law patterns', () => {
+    expect(
+      computeKinshipLabel([step('parent'), step('parent'), step('child'), step('spouse', 'M')])
+    ).toBe('uncle by marriage')
+  })
+})
+
+describe('computeKinshipLabel — distant relative fallback', () => {
+  it('falls back to "distant relative (N steps)" when a spouse hop is mid-path', () => {
+    expect(
+      computeKinshipLabel([step('parent'), step('spouse'), step('child', 'M')])
+    ).toBe('distant relative (3 steps)')
+  })
+
+  it('falls back to "distant relative (N steps)" for multiple spouse hops', () => {
+    expect(computeKinshipLabel([step('spouse'), step('spouse', 'F')])).toBe(
+      'distant relative (2 steps)'
+    )
+  })
+})

--- a/src/lib/kinship.ts
+++ b/src/lib/kinship.ts
@@ -1,0 +1,192 @@
+/**
+ * @fileoverview Pure step-sequence to English kinship label helper.
+ *
+ * Converts a shortest path between two people, expressed as a sequence of
+ * parent/child/spouse hops over the UNION/CHILD graph, into a
+ * human-readable relationship label (e.g. "second cousin once removed").
+ */
+
+export type Sex = 'M' | 'F' | null | undefined
+
+export type StepType = 'parent' | 'child' | 'spouse'
+
+export interface KinshipStep {
+  /** Direction of this hop relative to the person taking the previous step. */
+  type: StepType
+  /** Sex of the person arrived at after this step. */
+  sex?: Sex
+  /** Optional display name of the person arrived at after this step. */
+  name?: string
+}
+
+function sexWord(sex: Sex, male: string, female: string, neutral: string): string {
+  if (sex === 'M') return male
+  if (sex === 'F') return female
+  return neutral
+}
+
+/** Builds a "grand"/"great-grand" prefix for a given generation level (0 = none). */
+function grandPrefix(level: number): string {
+  if (level <= 0) return ''
+  if (level === 1) return 'grand'
+  return `great-`.repeat(level - 1) + 'grand'
+}
+
+/** Builds a "great-" prefix (no "grand") for a given generation level (0 = none). */
+function greatPrefix(level: number): string {
+  if (level <= 0) return ''
+  return 'great-'.repeat(level)
+}
+
+const ORDINAL_WORDS = [
+  'zeroth',
+  'first',
+  'second',
+  'third',
+  'fourth',
+  'fifth',
+  'sixth',
+  'seventh',
+  'eighth',
+  'ninth',
+  'tenth',
+]
+
+function ordinal(n: number): string {
+  if (n >= 0 && n < ORDINAL_WORDS.length) return ORDINAL_WORDS[n]
+  const rem100 = n % 100
+  if (rem100 >= 11 && rem100 <= 13) return `${n}th`
+  const suffix = ['th', 'st', 'nd', 'rd'][n % 10] ?? 'th'
+  return `${n}${suffix}`
+}
+
+function removalSuffix(removal: number): string {
+  if (removal === 0) return ''
+  if (removal === 1) return ' once removed'
+  if (removal === 2) return ' twice removed'
+  return ` ${removal} times removed`
+}
+
+function countGenerations(steps: KinshipStep[]): { up: number; down: number } {
+  let up = 0
+  let down = 0
+  for (const step of steps) {
+    if (step.type === 'parent') up++
+    else if (step.type === 'child') down++
+  }
+  return { up, down }
+}
+
+/**
+ * Labels a purely blood (parent/child only) relationship given the number
+ * of generations up to the common ancestor and down to the target.
+ */
+function bloodRelationLabel(up: number, down: number, sex: Sex): string {
+  if (up === 0 && down === 0) return 'self'
+
+  if (down === 0) {
+    const level = up - 1
+    const term = sexWord(sex, 'father', 'mother', 'parent')
+    return level === 0 ? term : grandPrefix(level) + term
+  }
+
+  if (up === 0) {
+    const level = down - 1
+    const term = sexWord(sex, 'son', 'daughter', 'child')
+    return level === 0 ? term : grandPrefix(level) + term
+  }
+
+  if (up === 1 && down === 1) {
+    return sexWord(sex, 'brother', 'sister', 'sibling')
+  }
+
+  if (up === 1 && down >= 2) {
+    const level = down - 2
+    const term = sexWord(sex, 'nephew', 'niece', 'nibling')
+    return level === 0 ? term : grandPrefix(level) + term
+  }
+
+  if (down === 1 && up >= 2) {
+    const level = up - 2
+    const term = sexWord(sex, 'uncle', 'aunt', 'aunt/uncle')
+    return greatPrefix(level) + term
+  }
+
+  const degree = Math.min(up, down) - 1
+  const removal = Math.abs(up - down)
+  return `${ordinal(degree)} cousin${removalSuffix(removal)}`
+}
+
+/**
+ * Labels the spouse of a blood relative ("theirs"), or a blood relative of
+ * a spouse ("spouses"), using conventional in-law/step terminology for the
+ * common cases and a "by marriage" fallback otherwise.
+ */
+function inLawLabel(up: number, down: number, sex: Sex, direction: 'theirs' | 'spouses'): string {
+  if (up === 1 && down === 0) {
+    return direction === 'theirs'
+      ? sexWord(sex, 'stepfather', 'stepmother', 'step-parent')
+      : sexWord(sex, 'father-in-law', 'mother-in-law', 'parent-in-law')
+  }
+
+  if (up === 0 && down === 1) {
+    return direction === 'theirs'
+      ? sexWord(sex, 'son-in-law', 'daughter-in-law', 'child-in-law')
+      : sexWord(sex, 'stepson', 'stepdaughter', 'stepchild')
+  }
+
+  if (up === 1 && down === 1) {
+    return sexWord(sex, 'brother-in-law', 'sister-in-law', 'sibling-in-law')
+  }
+
+  return `${bloodRelationLabel(up, down, sex)} by marriage`
+}
+
+/**
+ * Converts a kinship step sequence into an English relationship label.
+ *
+ * Supports direct blood relations (parent/child, grandparent/grandchild
+ * with great- prefixes, sibling, uncle/aunt, niece/nephew, and a
+ * generalized Nth-cousin-M-times-removed formula), a direct spouse, and
+ * simple in-law/step fallbacks for a single spouse hop at either end of an
+ * otherwise blood path. Anything else (a spouse hop mid-path, or more than
+ * one spouse hop) falls back to "distant relative (N steps)".
+ *
+ * @param steps - Ordered hops from the source person to the target person
+ * @returns A human-readable relationship label, e.g. "second cousin once removed"
+ */
+export function computeKinshipLabel(steps: KinshipStep[]): string {
+  if (steps.length === 0) return 'self'
+
+  const spouseIndices: number[] = []
+  steps.forEach((step, i) => {
+    if (step.type === 'spouse') spouseIndices.push(i)
+  })
+
+  const targetSex = steps[steps.length - 1].sex
+
+  if (spouseIndices.length === 0) {
+    const { up, down } = countGenerations(steps)
+    return bloodRelationLabel(up, down, targetSex)
+  }
+
+  if (spouseIndices.length === 1 && steps.length === 1) {
+    return sexWord(targetSex, 'husband', 'wife', 'spouse')
+  }
+
+  if (spouseIndices.length === 1) {
+    const spouseIndex = spouseIndices[0]
+
+    if (spouseIndex === steps.length - 1) {
+      const { up, down } = countGenerations(steps.slice(0, -1))
+      return inLawLabel(up, down, targetSex, 'theirs')
+    }
+
+    if (spouseIndex === 0) {
+      const { up, down } = countGenerations(steps.slice(1))
+      return inLawLabel(up, down, targetSex, 'spouses')
+    }
+  }
+
+  return `distant relative (${steps.length} steps)`
+}

--- a/src/lib/kinship.ts
+++ b/src/lib/kinship.ts
@@ -25,14 +25,12 @@ function sexWord(sex: Sex, male: string, female: string, neutral: string): strin
   return neutral
 }
 
-/** Builds a "grand"/"great-grand" prefix for a given generation level (0 = none). */
 function grandPrefix(level: number): string {
   if (level <= 0) return ''
   if (level === 1) return 'grand'
-  return `great-`.repeat(level - 1) + 'grand'
+  return 'great-'.repeat(level - 1) + 'grand'
 }
 
-/** Builds a "great-" prefix (no "grand") for a given generation level (0 = none). */
 function greatPrefix(level: number): string {
   if (level <= 0) return ''
   return 'great-'.repeat(level)
@@ -81,19 +79,27 @@ function countGenerations(steps: KinshipStep[]): { up: number; down: number } {
  * Labels a purely blood (parent/child only) relationship given the number
  * of generations up to the common ancestor and down to the target.
  */
+function termWithPrefix(
+  level: number,
+  sex: Sex,
+  male: string,
+  female: string,
+  neutral: string,
+  prefixFn: (n: number) => string
+): string {
+  const term = sexWord(sex, male, female, neutral)
+  return level === 0 ? term : prefixFn(level) + term
+}
+
 function bloodRelationLabel(up: number, down: number, sex: Sex): string {
   if (up === 0 && down === 0) return 'self'
 
   if (down === 0) {
-    const level = up - 1
-    const term = sexWord(sex, 'father', 'mother', 'parent')
-    return level === 0 ? term : grandPrefix(level) + term
+    return termWithPrefix(up - 1, sex, 'father', 'mother', 'parent', grandPrefix)
   }
 
   if (up === 0) {
-    const level = down - 1
-    const term = sexWord(sex, 'son', 'daughter', 'child')
-    return level === 0 ? term : grandPrefix(level) + term
+    return termWithPrefix(down - 1, sex, 'son', 'daughter', 'child', grandPrefix)
   }
 
   if (up === 1 && down === 1) {
@@ -101,15 +107,11 @@ function bloodRelationLabel(up: number, down: number, sex: Sex): string {
   }
 
   if (up === 1 && down >= 2) {
-    const level = down - 2
-    const term = sexWord(sex, 'nephew', 'niece', 'nibling')
-    return level === 0 ? term : grandPrefix(level) + term
+    return termWithPrefix(down - 2, sex, 'nephew', 'niece', 'nibling', grandPrefix)
   }
 
   if (down === 1 && up >= 2) {
-    const level = up - 2
-    const term = sexWord(sex, 'uncle', 'aunt', 'aunt/uncle')
-    return greatPrefix(level) + term
+    return termWithPrefix(up - 2, sex, 'uncle', 'aunt', 'aunt/uncle', greatPrefix)
   }
 
   const degree = Math.min(up, down) - 1


### PR DESCRIPTION
Part of #146.

Implements the backend half of the relationship calculator: public `GET /api/relationship` shortest-path endpoint and the `src/lib/kinship.ts` naming helper, both with thorough unit tests.

Remaining UI/E2E work from #146 (PersonDrawer "How related to root?" affordance and the `relationship-calculator.spec.ts` E2E spec) is tracked in #162.